### PR TITLE
Update GTest to 1.8.1

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -69,7 +69,7 @@ hunter_default_version(GSL VERSION 2.1.0-p2)
 if(MSVC80)
   hunter_default_version(GTest VERSION 1.7.0-hunter-6)
 else()
-  hunter_default_version(GTest VERSION 1.8.0-hunter-p11)
+  hunter_default_version(GTest VERSION 1.8.1)
 endif()
 
 hunter_default_version(HalideIR VERSION 0.0-32057b5-p0)

--- a/cmake/projects/GTest/hunter.cmake
+++ b/cmake/projects/GTest/hunter.cmake
@@ -227,6 +227,18 @@ hunter_add_version(
     76c6aec038f7d7258bf5c4f45c4817b34039d285
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    GTest
+    VERSION
+    "1.8.1"
+    URL
+    "https://github.com/google/googletest/archive/release-1.8.1.tar.gz"
+    SHA1
+    152b849610d91a9dfa1401293f43230c2e0c33f8
+)
+
+
 if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0)
   set(_gtest_license "LICENSE")
 else()
@@ -237,6 +249,7 @@ hunter_cmake_args(
     GTest
     CMAKE_ARGS
     HUNTER_INSTALL_LICENSE_FILES=${_gtest_license}
+    gtest_force_shared_crt=TRUE
 )
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)

--- a/examples/GTest/CMakeLists.txt
+++ b/examples/GTest/CMakeLists.txt
@@ -13,10 +13,7 @@ add_executable(foo foo.cpp)
 
 hunter_add_package(GTest)
 find_package(GTest CONFIG REQUIRED)
-target_link_libraries(foo PUBLIC GTest::main)
-
-find_package(GMock CONFIG REQUIRED)
-target_link_libraries(foo PUBLIC GMock::gmock)
+target_link_libraries(foo PRIVATE GTest::gtest_main GTest::gmock)
 
 if(NOT EXISTS "${GTest_LICENSES}")
   message(FATAL_ERROR "File not found: '${GTest_LICENSES}")


### PR DESCRIPTION
* I've followed [this guide](https://docs.hunter.sh/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/chfast/hunter/builds/27385838
  * https://travis-ci.org/chfast/hunter/builds/584474286

The AppVeyor CI config is broken.