### PR TITLE
Remove developer name and link to developer profile in documentation

### DIFF
--- a/docs/packages/pkg/foo.rst
+++ b/docs/packages/pkg/foo.rst
@@ -13,7 +13,7 @@ foo
 -  `Official <https://official_foo>`__
 -  `Hunterized <https://github.com/hunter-packages/foo>`__
 -  `Example <https://github.com/ruslo/hunter/blob/master/examples/foo/CMakeLists.txt>`__
--  Added by `foo_developer <https://github.com/foo_developer>`__ (`pr-N <https://github.com/ruslo/hunter/pull/N>`__)
+-  Added in PR `pr-N <https://github.com/ruslo/hunter/pull/N>`__
 
 .. literalinclude:: /../examples/foo/CMakeLists.txt
   :language: cmake


### PR DESCRIPTION

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

This PR removes most of the "Added by developer ..." line.