### PR TITLE
Fixed broken link in zip.rst

### DIFF
--- a/docs/packages/pkg/zip.rst
+++ b/docs/packages/pkg/zip.rst
@@ -10,7 +10,7 @@
 zip
 ===
 
--  `Official <https://https://github.com/kuba--/zip>`__
+-  `Official <https://github.com/kuba--/zip>`__
 -  `Example <https://github.com/ruslo/hunter/blob/master/examples/zip/CMakeLists.txt>`__
 -  Added by `Rahul Sheth <https://github.com/rbsheth>`__ (`pr-1878 <https://github.com/ruslo/hunter/pull/1878>`__)
 


### PR DESCRIPTION
<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->
I noticed a broken link browsing the documentation.

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[No]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---
<!--- END -->
