### PR TITLE
Add chromium_zlib package as ZLIB

### DIFF
--- a/cmake/projects/ZLIB/hunter.cmake
+++ b/cmake/projects/ZLIB/hunter.cmake
@@ -74,6 +74,17 @@ hunter_add_version(
     fbb8be77db5cb3f4d1b269f273a357d22ccc4b32
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    ZLIB
+    VERSION
+    "0.0.0-chromium-f87c2b10efb4-p0"
+    URL
+    "https://github.com/hunter-packages/chromium_zlib/archive/v0.0.0-f87c2b10efb4-p0.tar.gz"
+    SHA1
+    2fc1f19ef5ba48c415a614e56e1c12507f4676ab
+)
+
 hunter_pick_scheme(DEFAULT url_sha1_cmake)
 hunter_cacheable(ZLIB)
 hunter_download(PACKAGE_NAME ZLIB


### PR DESCRIPTION
Upstream commit from https://github.com/ruslo/hunter

I modified this to be a non-default version of the ZLIB package, since it should be a drop in replacement but users may not want this version and adding both `zlib` and `chromium_zlib` may cause conflicts.