### PR TITLE
Fix build error in Xcode when building boost

### DIFF
--- a/cmake/projects/Boost/atomic/hunter.cmake
+++ b/cmake/projects/Boost/atomic/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     atomic
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/chrono/hunter.cmake
+++ b/cmake/projects/Boost/chrono/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     chrono
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/context/hunter.cmake
+++ b/cmake/projects/Boost/context/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     context
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/contract/hunter.cmake
+++ b/cmake/projects/Boost/contract/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     contract
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/coroutine/hunter.cmake
+++ b/cmake/projects/Boost/coroutine/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     coroutine
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/date_time/hunter.cmake
+++ b/cmake/projects/Boost/date_time/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     date_time
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/exception/hunter.cmake
+++ b/cmake/projects/Boost/exception/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     exception
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/fiber/hunter.cmake
+++ b/cmake/projects/Boost/fiber/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     fiber
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/filesystem/hunter.cmake
+++ b/cmake/projects/Boost/filesystem/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     filesystem
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/graph/hunter.cmake
+++ b/cmake/projects/Boost/graph/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/graph_parallel/hunter.cmake
+++ b/cmake/projects/Boost/graph_parallel/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph_parallel
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -411,4 +411,4 @@ endif()
 
 hunter_pick_scheme(DEFAULT url_sha1_boost)
 hunter_cacheable(Boost)
-hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "44")
+hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "45")

--- a/cmake/projects/Boost/hunter.cmake.in
+++ b/cmake/projects/Boost/hunter.cmake.in
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     boost_component
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/iostreams/hunter.cmake
+++ b/cmake/projects/Boost/iostreams/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     iostreams
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/locale/hunter.cmake
+++ b/cmake/projects/Boost/locale/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     locale
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/log/hunter.cmake
+++ b/cmake/projects/Boost/log/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     log
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/math/hunter.cmake
+++ b/cmake/projects/Boost/math/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     math
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/mpi/hunter.cmake
+++ b/cmake/projects/Boost/mpi/hunter.cmake
@@ -26,5 +26,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     mpi
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/program_options/hunter.cmake
+++ b/cmake/projects/Boost/program_options/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     program_options
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/python/hunter.cmake
+++ b/cmake/projects/Boost/python/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     python
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/random/hunter.cmake
+++ b/cmake/projects/Boost/random/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     random
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/regex/hunter.cmake
+++ b/cmake/projects/Boost/regex/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     regex
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/scripts/create-boost-1-66-ios-fatlib.sh
+++ b/cmake/projects/Boost/scripts/create-boost-1-66-ios-fatlib.sh
@@ -12,11 +12,25 @@ INSTALL_DIR="$4"
 
 COMMON_DIR="${BUILD_DIR}/bin.v2/libs/${DIRNAME}/build"
 
-IPHONE_DEBUG=`find "${COMMON_DIR}/darwin-gnu-iphoneos/debug" -name "libboost_${LIBNAME}[^_]*.a"`
-IPHONE_RELEASE=`find "${COMMON_DIR}/darwin-gnu-iphoneos/release" -name "libboost_${LIBNAME}[^_]*.a"`
+if [[ -d "${COMMON_DIR}/darwin-gnu-iphoneos/debug" ]]
+then
+  IPHONE_DEBUG=`find "${COMMON_DIR}/darwin-gnu-iphoneos/debug" -name "libboost_${LIBNAME}[^_]*.a"`
+fi
 
-SIM_DEBUG=`find "${COMMON_DIR}/darwin-gnu-iphonesimulator/debug" -name "libboost_${LIBNAME}[^_]*.a"`
-SIM_RELEASE=`find "${COMMON_DIR}/darwin-gnu-iphonesimulator/release" -name "libboost_${LIBNAME}[^_]*.a"`
+if [[ -d "${COMMON_DIR}/darwin-gnu-iphoneos/release" ]]
+then
+  IPHONE_RELEASE=`find "${COMMON_DIR}/darwin-gnu-iphoneos/release" -name "libboost_${LIBNAME}[^_]*.a"`
+fi
+
+if [[ -d "${COMMON_DIR}/darwin-gnu-iphonesimulator/debug" ]]
+then
+  SIM_DEBUG=`find "${COMMON_DIR}/darwin-gnu-iphonesimulator/debug" -name "libboost_${LIBNAME}[^_]*.a"`
+fi
+
+if [[ -d "${COMMON_DIR}/darwin-gnu-iphonesimulator/release" ]]
+then
+  SIM_RELEASE=`find "${COMMON_DIR}/darwin-gnu-iphonesimulator/release" -name "libboost_${LIBNAME}[^_]*.a"`
+fi
 
 echo "-- [iOS universal] IPHONE_DEBUG: $IPHONE_DEBUG"
 echo "-- [iOS universal] IPHONE_RELEASE: $IPHONE_RELEASE"

--- a/cmake/projects/Boost/scripts/create-boost-ios-fatlib.sh
+++ b/cmake/projects/Boost/scripts/create-boost-ios-fatlib.sh
@@ -12,11 +12,25 @@ INSTALL_DIR="$4"
 
 COMMON_DIR="${BUILD_DIR}/bin.v2/libs/${DIRNAME}/build"
 
-IPHONE_DEBUG=`find "${COMMON_DIR}/darwin-iphoneos/debug" -name "libboost_${LIBNAME}[^_]*.a"`
-IPHONE_RELEASE=`find "${COMMON_DIR}/darwin-iphoneos/release" -name "libboost_${LIBNAME}[^_]*.a"`
+if [[ -d "${COMMON_DIR}/darwin-iphoneos/debug" ]]
+then
+  IPHONE_DEBUG=`find "${COMMON_DIR}/darwin-iphoneos/debug" -name "libboost_${LIBNAME}[^_]*.a"`
+fi
 
-SIM_DEBUG=`find "${COMMON_DIR}/darwin-iphonesimulator/debug" -name "libboost_${LIBNAME}[^_]*.a"`
-SIM_RELEASE=`find "${COMMON_DIR}/darwin-iphonesimulator/release" -name "libboost_${LIBNAME}[^_]*.a"`
+if [[ -d "${COMMON_DIR}/darwin-iphoneos/release" ]]
+then
+  IPHONE_RELEASE=`find "${COMMON_DIR}/darwin-iphoneos/release" -name "libboost_${LIBNAME}[^_]*.a"`
+fi
+
+if [[ -d "${COMMON_DIR}/darwin-iphonesimulator/debug" ]]
+then
+  SIM_DEBUG=`find "${COMMON_DIR}/darwin-iphonesimulator/debug" -name "libboost_${LIBNAME}[^_]*.a"`
+fi
+
+if [[ -d "${COMMON_DIR}/darwin-iphonesimulator/release" ]]
+then
+  SIM_RELEASE=`find "${COMMON_DIR}/darwin-iphonesimulator/release" -name "libboost_${LIBNAME}[^_]*.a"`
+fi
 
 echo "-- [iOS universal] IPHONE_DEBUG: $IPHONE_DEBUG"
 echo "-- [iOS universal] IPHONE_RELEASE: $IPHONE_RELEASE"

--- a/cmake/projects/Boost/serialization/hunter.cmake
+++ b/cmake/projects/Boost/serialization/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     serialization
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/signals/hunter.cmake
+++ b/cmake/projects/Boost/signals/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     signals
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/stacktrace/hunter.cmake
+++ b/cmake/projects/Boost/stacktrace/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     stacktrace
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/system/hunter.cmake
+++ b/cmake/projects/Boost/system/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     system
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/test/hunter.cmake
+++ b/cmake/projects/Boost/test/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     test
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/thread/hunter.cmake
+++ b/cmake/projects/Boost/thread/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     thread
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/timer/hunter.cmake
+++ b/cmake/projects/Boost/timer/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     timer
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )

--- a/cmake/projects/Boost/wave/hunter.cmake
+++ b/cmake/projects/Boost/wave/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     wave
-    PACKAGE_INTERNAL_DEPS_ID "44"
+    PACKAGE_INTERNAL_DEPS_ID "45"
 )


### PR DESCRIPTION
This change will fix boost build with Xcode.
XCode is failing with following error:
`Command /bin/sh emitted errors but did not return a nonzero exit code to indicate failure`
if the directory doesn't exists and find throws an error like:
`find: .../.hunter/_Base/xxxxxxx/9b6965d/a045106/Build/Boost/__log/Source/bin.v2/libs/log/build/darwin-iphonesimulator/release: No such file or directory`

I'm not sure yet, if I should create a "new boost version" from `1.71.0-p0` to `1.71.0-p1` in hunter `cmake/configs/default.cmake` and following the [Update manual](https://docs.hunter.sh/en/latest/creating-new/update.html) ? But there is no source code change? Or should I increment the `PACKAGE_INTERNAL_DEPS_ID` from `44` to `45` for all boost components ?


