### PR TITLE
Update bzip2 to 1.0.8 (CVE-2016-3189 and CVE-2019-12900)

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -30,7 +30,7 @@ hunter_default_version(ArrayFire VERSION 3.3.1-p0)
 hunter_default_version(Assimp VERSION 5.0.0-07779a7a)
 hunter_default_version(Async++ VERSION 0.0.3-hunter)
 hunter_default_version(Avahi VERSION 0.6.31)
-hunter_default_version(BZip2 VERSION 1.0.6-p4)
+hunter_default_version(BZip2 VERSION 1.0.8-p4)
 hunter_default_version(Beast VERSION 1.0.0-b84-hunter-0)
 
 if(MINGW)

--- a/cmake/projects/BZip2/hunter.cmake
+++ b/cmake/projects/BZip2/hunter.cmake
@@ -54,6 +54,17 @@ hunter_add_version(
     11fb2b502a425ccc07142f869cce8b3bbae5f1ea
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    BZip2
+    VERSION
+    "1.0.8-p4"
+    URL
+    "https://github.com/Bjoe/bzip2/archive/hunter-1.0.8.zip"
+    SHA1
+    d5617ec07546fa51d269bde92b5fd2f8481a1ae9
+)
+
 hunter_cmake_args(
     BZip2
     CMAKE_ARGS


### PR DESCRIPTION
* I've followed [this guide](https://docs.hunter.sh/en/latest/creating-new/update.html)
  step by step carefully. **Yes**

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/Bjoe/hunter/builds/29271450
  * https://travis-ci.org/Bjoe/hunter/builds/619998074
