### PR TITLE
Update spdlog to 1.4.2-p2, fixing missing cassert include

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -470,7 +470,7 @@ if(MSVC_VERSION LESS 1800)
   # for VS12 - version without support C++11
   hunter_default_version(spdlog VERSION 1.0.0-p0)
 else()
-  hunter_default_version(spdlog VERSION 1.4.2-p0)
+  hunter_default_version(spdlog VERSION 1.4.2-58e6890-p0)
 endif()
 
 hunter_default_version(spirv-cross VERSION 20190906)

--- a/cmake/projects/spdlog/hunter.cmake
+++ b/cmake/projects/spdlog/hunter.cmake
@@ -108,6 +108,17 @@ hunter_add_version(
     61136ee6120fe069d37df4ad11628a2a0622b447
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    spdlog
+    VERSION
+    "1.4.2-58e6890-p0"
+    URL
+    "https://github.com/cpp-pm/spdlog/archive/v1.4.2-58e6890-p0.tar.gz"
+    SHA1
+    5dd633311d1aec79404d6694b452745b80f1a7d1
+)
+
 hunter_cmake_args(
     spdlog
     CMAKE_ARGS


### PR DESCRIPTION
* I've followed [this guide](https://cpp-pm-hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/dan-42/hunter/builds/29827625
  * https://travis-ci.org/dan-42/hunter/builds/631261840


the **-p2**  means that I use the latest changes from spdlogs branch  `` v1.x `` which includes a fix when compiling on gcc9.2 which misses an **#include <cassert>**

Please delete the following branch `` hunter-1.4.2-p1 ``  from the repo **https://github.com/cpp-pm/spdlog**  as I created it accidently from spdlog's  `` master ``-branch which is wrong.
And I do not have the privileges to delete a protected branch.

PING: @bkotzz @rbsheth

