### PR TITLE
Boost Python: Add optional numpy support

### DIFF
--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -42,6 +42,13 @@ hunter_assert_not_empty_string("@HUNTER_Boost_VERSION@")
 hunter_assert_not_empty_string("@HUNTER_PACKAGE_SCRIPT_DIR@")
 hunter_assert_not_empty_string("@HUNTER_TLS_VERIFY@")
 
+# Add/enable NumPy if it is requested
+if (HUNTER_ENABLE_BOOST_PYTHON_NUMPY)
+  cmake_minimum_required(VERSION 3.12)
+  hunter_add_package(pip_numpy)
+  find_package(pip_numpy CONFIG REQUIRED)
+endif()
+
 # get list of boost components for given version
 hunter_get_boost_libs(VERSION "@HUNTER_Boost_VERSION@" LIBS boost_libs)
 
@@ -309,29 +316,62 @@ hunter_parse_cmake_args_for_keyword(
 
 # set up paths for python in boost.user.jam
 if(NOT python_version STREQUAL "")
-  find_package(PythonInterp ${python_version} EXACT QUIET)
-  if(NOT PYTHONINTERP_FOUND)
-    hunter_user_error("Python Interpreter for Python version ${python_version} not found.")
-  endif()
-  set(python_executable ${PYTHON_EXECUTABLE})
-  find_package(PythonLibs ${python_version} EXACT QUIET)
-  if(NOT PYTHONLIBS_FOUND)
-    hunter_user_error("Python runtime library directory for Python version ${python_version} not found.")
-  endif()
-  # get the main Python include directory containing pyconfig.h
-  list(LENGTH PYTHON_INCLUDE_DIRS python_include_dir_list_length)
-  if(python_include_dir_list_length EQUAL 1)
-    set(python_include_directory "${PYTHON_INCLUDE_DIRS}")
+  if(HUNTER_ENABLE_BOOST_PYTHON_NUMPY)
+    # Use the CMake >= 3.12 way (names are all a bit different)
+    find_package(Python REQUIRED COMPONENTS Interpreter Development NumPy)
+    if(NOT Python_Interpreter_FOUND)
+      hunter_user_error("Python Interpreter for Python version ${python_version} not found.")
+    endif()
+    set(python_executable ${Python_EXECUTABLE})
+    if(NOT Python_Development_FOUND)
+      hunter_user_error("Python development artifacts for Python version ${python_version} not found.")
+    endif()
+    if(NOT Python_NumPy_FOUND)
+      hunter_user_error("Python NumPy for Python version ${python_version} not found.")
+    endif()
+    set(python_maj_min "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+    # get the main Python include directory containing pyconfig.h
+    list(LENGTH Python_INCLUDE_DIRS python_include_dir_list_length)
+    if(python_include_dir_list_length EQUAL 1)
+      set(python_include_directory "${Python_INCLUDE_DIRS}")
+    else()
+      list(GET Python_INCLUDE_DIRS 0 python_include_directory)
+    endif()
+    # get directory of optimized library
+    list(LENGTH Python_LIBRARIES python_libraries_list_length)
+    if(python_libraries_list_length EQUAL 1)
+      set(python_optimized_library_path "${Python_LIBRARIES}")
+    else()
+      list(GET Python_LIBRARIES 1 python_optimized_library_path)
+    endif()
   else()
-    list(GET PYTHON_INCLUDE_DIRS 0 python_include_directory)
+    # Use the CMake < 3.12 way
+    find_package(PythonInterp ${python_version} EXACT QUIET)
+    if(NOT PYTHONINTERP_FOUND)
+      hunter_user_error("Python Interpreter for Python version ${python_version} not found.")
+    endif()
+    set(python_executable ${PYTHON_EXECUTABLE})
+    find_package(PythonLibs ${python_version} EXACT QUIET)
+    if(NOT PYTHONLIBS_FOUND)
+      hunter_user_error("Python runtime library directory for Python version ${python_version} not found.")
+    endif()
+    set(python_maj_min "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+    # get the main Python include directory containing pyconfig.h
+    list(LENGTH PYTHON_INCLUDE_DIRS python_include_dir_list_length)
+    if(python_include_dir_list_length EQUAL 1)
+      set(python_include_directory "${PYTHON_INCLUDE_DIRS}")
+    else()
+      list(GET PYTHON_INCLUDE_DIRS 0 python_include_directory)
+    endif()
+    # get directory of optimized library
+    list(LENGTH PYTHON_LIBRARIES python_libraries_list_length)
+    if(python_libraries_list_length EQUAL 1)
+      set(python_optimized_library_path "${PYTHON_LIBRARIES}")
+    else()
+      list(GET PYTHON_LIBRARIES 1 python_optimized_library_path)
+    endif()
   endif()
-  # get directory of optimized library
-  list(LENGTH PYTHON_LIBRARIES python_libraries_list_length)
-  if(python_libraries_list_length EQUAL 1)
-    set(python_optimized_library_path "${PYTHON_LIBRARIES}")
-  else()
-    list(GET PYTHON_LIBRARIES 1 python_optimized_library_path)
-  endif()
+
   get_filename_component(python_library_directory "${python_optimized_library_path}" DIRECTORY)
   if("@MSVC@")
     string(REPLACE "/" "\\\\" python_executable "${python_executable}")
@@ -340,7 +380,7 @@ if(NOT python_version STREQUAL "")
   endif()
   file(
     APPEND ${boost_user_jam}
-    "using python  : ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} : \"${python_executable}\" : \"${python_include_directory}\" : \"${python_library_directory}\" ;\n"
+    "using python  : ${python_maj_min} : \"${python_executable}\" : \"${python_include_directory}\" : \"${python_library_directory}\" ;\n"
   )
 endif()
 

--- a/docs/packages/pkg/Boost.rst
+++ b/docs/packages/pkg/Boost.rst
@@ -150,6 +150,27 @@ Example for Python 3:
       find_package(Boost CONFIG REQUIRED python36)
     endif()
 
+
+Python NumPy
+------------
+
+To build the NumPy plugin for Boost Python use option ``HUNTER_ENABLE_BOOST_PYTHON_NUMPY=True``.
+This will require ``pip_numpy`` and therefore ``hunter_venv``, see their docs for details and
+requirements.
+
+Example:
+
+.. code-block:: cmake
+
+    # config.cmake
+    hunter_config(
+      Boost
+      VERSION ${HUNTER_Boost_VERSION}
+      CMAKE_ARGS
+      PYTHON_VERSION=${PYTHON_VERSION}
+      HUNTER_ENABLE_BOOST_PYTHON_NUMPY=True
+    )
+
 Math
 ----
 

--- a/examples/Boost-python-numpy/CMakeLists.txt
+++ b/examples/Boost-python-numpy/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) 2013, Ruslan Baratov
+# Modified work: Copyright (c) 2018, Gregory Kramida
+# All rights reserved.
+
+cmake_minimum_required(VERSION 3.12)
+option(HUNTER_BUILD_SHARED_LIBS "..." ON)
+
+# Configure:
+set(PYTHON_VERSION 3.5)
+set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
+
+# Emulate HunterGate:
+# * https://github.com/hunter-packages/gate
+include("../common.cmake")
+
+project(download-boost)
+
+# Requires python version 3.5. Change this in config.cmake if necessary.
+hunter_add_package(Boost COMPONENTS python)
+find_package(Boost CONFIG REQUIRED python35 numpy35)
+
+# pip_numpy must come before we find Python as it enables the virtualenv
+find_package(pip_numpy CONFIG REQUIRED)
+find_package(Python ${PYTHON_VERSION} REQUIRED COMPONENTS Interpreter Development NumPy)
+
+Python_add_library(foo MODULE foo.cpp)
+target_link_libraries(
+    foo
+    PUBLIC
+    Boost::python35
+    Boost::numpy35
+)

--- a/examples/Boost-python-numpy/config.cmake
+++ b/examples/Boost-python-numpy/config.cmake
@@ -1,0 +1,4 @@
+# Note: PYTHON_VERSION is optional. Refer to Boost package documentation on how
+# and when to use it: https://cpp-pm-hunter.readthedocs.io/en/latest/packages/pkg/Boost.html#cmake-options
+hunter_config(Boost VERSION ${HUNTER_Boost_VERSION} CMAKE_ARGS PYTHON_VERSION=${PYTHON_VERSION} HUNTER_ENABLE_BOOST_PYTHON_NUMPY=True)
+hunter_config(hunter_venv VERSION ${HUNTER_hunter_venv_VERSION} CMAKE_ARGS HUNTER_VENV_PYTHON_VERSION=${PYTHON_VERSION})

--- a/examples/Boost-python-numpy/foo.cpp
+++ b/examples/Boost-python-numpy/foo.cpp
@@ -1,0 +1,22 @@
+#include <boost/python.hpp>
+#include <boost/python/numpy.hpp>
+
+char const* greet()
+{
+   return "hello, world";
+}
+
+boost::python::numpy::ndarray arr()
+{
+    using namespace boost::python;
+    return numpy::zeros(
+        make_tuple(2, 2),
+        numpy::dtype::get_builtin<float_t>());
+}
+
+BOOST_PYTHON_MODULE(hello_ext)
+{
+    using namespace boost::python;
+    def("greet", greet);
+    def("arr", arr);
+}


### PR DESCRIPTION
* Use CMAKE option HUNTER_ENABLE_BOOST_PYTHON_NUMPY to enable

---

This change adds a CMAKE option to Boost install to allow build and install of the boost-python-numpy plugin, which is part of boost-python since around boost 1.63. The change is currently labelled WIP as I would like feedback on the docs and flag names etc and the builds are running. I have included and example and added that to the testing matrix for boost in a PR here (https://github.com/cpp-pm/hunter-testing/pull/27).

---

* I've followed [this guide](https://cpp-pm-hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://travis-ci.org/hjmallon/hunter/builds/631918882
  * https://ci.appveyor.com/project/hjmallon/hunter/builds/29858120
