### PR TITLE
Update CI Python versions where they have updated upstream

### DIFF
--- a/cmake/projects/hunter_venv/hunter.cmake
+++ b/cmake/projects/hunter_venv/hunter.cmake
@@ -23,7 +23,7 @@ hunter_add_version(
 
 # DOCUMENTATION_START {
 if(APPLE)
-  set(__hunter_venv_default_python "3.6.5")
+  set(__hunter_venv_default_python "3.7.5")
 elseif(WIN32)
   set(__hunter_venv_default_python "3.6.8")
 else()

--- a/cmake/projects/hunter_venv/hunter.cmake
+++ b/cmake/projects/hunter_venv/hunter.cmake
@@ -24,6 +24,8 @@ hunter_add_version(
 # DOCUMENTATION_START {
 if(APPLE)
   set(__hunter_venv_default_python "3.7.5")
+elseif(MSYS)
+  set(__hunter_venv_default_python "3.7.5")
 elseif(WIN32)
   set(__hunter_venv_default_python "3.6.8")
 else()


### PR DESCRIPTION
* Travis make no guarantees for Python version
  stability on their images for macOS.

The version numbers in this file are meant to match those on the CI system. However, the macOS xcode9.4 image on Travis now has 3.7.5.

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**


Here is a Travis run of the failing `pkg.pip_numpy` branch with this change on top showing macOS build success:
* https://travis-ci.org/hjmallon/hunter/builds/632249789