### PR TITLE
Fix pip builds with up to date pkg.template

### DIFF
--- a/cmake/schemes/url_sha1_pip.cmake.in
+++ b/cmake/schemes/url_sha1_pip.cmake.in
@@ -83,7 +83,10 @@ configure_package_config_file(
     INSTALL_DESTINATION "${config_install_dir}"
 )
 
-if(HUNTER_STATUS_DEBUG)
+# We don't support verbose when building in MSVC as some pip packages (pip_numpy)
+# run config test builds which are intended to fail, but cause MSVC to think the
+# whole build has failed.
+if(HUNTER_STATUS_DEBUG AND NOT MSVC)
   set(pip_verbose "-vvv")
 else()
   set(pip_verbose "")


### PR DESCRIPTION
* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

After testing my PR (https://github.com/cpp-pm/hunter/pull/117) which is intended to fix https://github.com/cpp-pm/hunter/issues/115 I updated the `pip_numpy` test branch by merging `pkg.template`. This caused another failure in MSVC builds.

It seems the verbose option added to pip here https://github.com/cpp-pm/hunter/commit/9d7af40041326b7eeefc28a30536bb19dada742d can confuse MSVC if the output of the (working) build happens to include `error:`. I have disabled verbose pip output in MSVC contexts.

This is marked `BLOCKED` as it needs the other PR (https://github.com/cpp-pm/hunter/pull/117) to be merged first.