### PR TITLE
opentracing-cpp 1.6.0 SHA1 change to lowercase

### DIFF
--- a/cmake/projects/opentracing-cpp/hunter.cmake
+++ b/cmake/projects/opentracing-cpp/hunter.cmake
@@ -52,7 +52,7 @@ hunter_add_version(
     PACKAGE_NAME opentracing-cpp
     VERSION "1.6.0"
     URL "https://github.com/opentracing/opentracing-cpp/archive/v1.6.0.tar.gz"
-    SHA1 "F5DCCF21DC05CDDB6205164A8FD3CF210926EF6C")
+    SHA1 "f5dccf21dc05cddb6205164a8fd3cf210926ef6c")
 
 hunter_cmake_args(opentracing-cpp CMAKE_ARGS
     BUILD_TESTING=OFF ENABLE_LINTING=OFF)


### PR DESCRIPTION
Same like this PR https://github.com/cpp-pm/hunter/pull/73

The SHA check failed on CentOS env... error log 

```
...
-- verifying file...
       file='/root/.hunter/_Base/Download/opentracing-cpp/1.6.0/F5DCCF2/v1.6.0.tar.gz'
-- SHA1 hash of
    /root/.hunter/_Base/Download/opentracing-cpp/1.6.0/F5DCCF2/v1.6.0.tar.gz
  does not match expected value
    expected: 'F5DCCF21DC05CDDB6205164A8FD3CF210926EF6C'
      actual: 'f5dccf21dc05cddb6205164a8fd3cf210926ef6c'
-- Hash mismatch, removing...
-- Retry after 60 seconds (attempt #5) ...
-- downloading...
       src='https://github.com/opentracing/opentracing-cpp/archive/v1.6.0.tar.gz'
       dst='/root/.hunter/_Base/Download/opentracing-cpp/1.6.0/F5DCCF2/v1.6.0.tar.gz'
       timeout='none'
-- verifying file...
       file='/root/.hunter/_Base/Download/opentracing-cpp/1.6.0/F5DCCF2/v1.6.0.tar.gz'
-- SHA1 hash of
    /root/.hunter/_Base/Download/opentracing-cpp/1.6.0/F5DCCF2/v1.6.0.tar.gz
  does not match expected value
    expected: 'F5DCCF21DC05CDDB6205164A8FD3CF210926EF6C'
      actual: 'f5dccf21dc05cddb6205164a8fd3cf210926ef6c'
...
```