### PR TITLE
Fix boost build on MacOSx SDK 10.15

### DIFF
--- a/cmake/projects/Boost/atomic/hunter.cmake
+++ b/cmake/projects/Boost/atomic/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     atomic
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/chrono/hunter.cmake
+++ b/cmake/projects/Boost/chrono/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     chrono
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/context/hunter.cmake
+++ b/cmake/projects/Boost/context/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     context
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/contract/hunter.cmake
+++ b/cmake/projects/Boost/contract/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     contract
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/coroutine/hunter.cmake
+++ b/cmake/projects/Boost/coroutine/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     coroutine
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/date_time/hunter.cmake
+++ b/cmake/projects/Boost/date_time/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     date_time
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/exception/hunter.cmake
+++ b/cmake/projects/Boost/exception/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     exception
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/fiber/hunter.cmake
+++ b/cmake/projects/Boost/fiber/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     fiber
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/filesystem/hunter.cmake
+++ b/cmake/projects/Boost/filesystem/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     filesystem
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/graph/hunter.cmake
+++ b/cmake/projects/Boost/graph/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/graph_parallel/hunter.cmake
+++ b/cmake/projects/Boost/graph_parallel/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph_parallel
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -422,4 +422,4 @@ endif()
 
 hunter_pick_scheme(DEFAULT url_sha1_boost)
 hunter_cacheable(Boost)
-hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "45")
+hunter_download(PACKAGE_NAME Boost PACKAGE_INTERNAL_DEPS_ID "46")

--- a/cmake/projects/Boost/hunter.cmake.in
+++ b/cmake/projects/Boost/hunter.cmake.in
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     boost_component
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/iostreams/hunter.cmake
+++ b/cmake/projects/Boost/iostreams/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     iostreams
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/locale/hunter.cmake
+++ b/cmake/projects/Boost/locale/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     locale
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/log/hunter.cmake
+++ b/cmake/projects/Boost/log/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     log
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/math/hunter.cmake
+++ b/cmake/projects/Boost/math/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     math
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/mpi/hunter.cmake
+++ b/cmake/projects/Boost/mpi/hunter.cmake
@@ -26,5 +26,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     mpi
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/program_options/hunter.cmake
+++ b/cmake/projects/Boost/program_options/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     program_options
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/python/hunter.cmake
+++ b/cmake/projects/Boost/python/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     python
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/random/hunter.cmake
+++ b/cmake/projects/Boost/random/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     random
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/regex/hunter.cmake
+++ b/cmake/projects/Boost/regex/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     regex
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -434,6 +434,15 @@ if(CMAKE_HOST_WIN32)
     set(patch_cmd "@CMAKE_COMMAND@" -E echo "Dummy patch command")
     set(bootstrap_cmd "bootstrap.bat")
   endif()
+elseif(APPLE)
+  set(b2_cmd "./b2")
+  set(bootstrap_cmd
+      . "@HUNTER_GLOBAL_SCRIPT_DIR@/clear-all.sh" &&
+      ./bootstrap.sh
+      "--with-libraries=@HUNTER_PACKAGE_COMPONENT@"
+      "--prefix=@HUNTER_PACKAGE_INSTALL_PREFIX@"
+  )
+  set(patch_cmd "@CMAKE_COMMAND@" -E echo "Dummy patch command")
 else()
   set(b2_cmd "./b2")
   set(bootstrap_cmd "./bootstrap.sh")

--- a/cmake/projects/Boost/serialization/hunter.cmake
+++ b/cmake/projects/Boost/serialization/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     serialization
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/signals/hunter.cmake
+++ b/cmake/projects/Boost/signals/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     signals
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/stacktrace/hunter.cmake
+++ b/cmake/projects/Boost/stacktrace/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     stacktrace
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/system/hunter.cmake
+++ b/cmake/projects/Boost/system/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     system
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/test/hunter.cmake
+++ b/cmake/projects/Boost/test/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     test
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/thread/hunter.cmake
+++ b/cmake/projects/Boost/thread/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     thread
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/timer/hunter.cmake
+++ b/cmake/projects/Boost/timer/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     timer
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )

--- a/cmake/projects/Boost/wave/hunter.cmake
+++ b/cmake/projects/Boost/wave/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     wave
-    PACKAGE_INTERNAL_DEPS_ID "45"
+    PACKAGE_INTERNAL_DEPS_ID "46"
 )


### PR DESCRIPTION

* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **Yes**

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/Bjoe/hunter-t1t06/builds/30592132
  * https://travis-ci.org/Bjoe/hunter/builds/646466404

Boost introduced a new `bootstrap.sh` script and this fails on MacOSx builds since boost 1.71.
I take the approach from [url_sha1_boost_ios_library.cmake.in Line 181](https://github.com/cpp-pm/hunter/blob/8d115144573db21e5b57e1289b769b9a5ade821c/cmake/projects/Boost/schemes/url_sha1_boost_ios_library.cmake.in#L181)
