### PR TITLE
(Ready) - Fix sha1 for latest glbinding, current is sha1 to updater's archive 

### DIFF
--- a/cmake/projects/glbinding/hunter.cmake
+++ b/cmake/projects/glbinding/hunter.cmake
@@ -17,7 +17,7 @@ hunter_add_version(
     URL
     "https://github.com/cpp-pm/glbinding/archive/v3.1.0-p0.tar.gz"
     SHA1
-    0914870b8375539bdd3e02d8e349c53b9bf8da71
+    cedf73b1beadb93475e8b05647bd9c7a149bd3a3
 )
 
 hunter_add_version(


### PR DESCRIPTION
* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **Yes**

* I've tested this package remotely and have excluded all broken builds.
  Here is the links to the Travis/AppVeyor with status "All passed":

  * https://ci.appveyor.com/project/caseymcc/hunter/builds/30675491
  * https://travis-ci.org/caseymcc/hunter/builds/648051318

* This update will break few old toolchains.
  They are excluded in this pull request: https://github.com/cpp-pm/hunter-testing/pull/47
