### PR TITLE
Compares SHA1 strings in case insensitive.

### DIFF
--- a/cmake/modules/hunter_make_directory.cmake
+++ b/cmake/modules/hunter_make_directory.cmake
@@ -27,7 +27,9 @@ function(hunter_make_directory parent sha1 result)
       hunter_internal_error("Not found: ${sha1_path}")
     endif()
     file(READ "${sha1_path}" sha1_value)
-    string(COMPARE EQUAL "${sha1_value}" "${sha1}" is_equal)
+    string(TOLOWER "${sha1_value}" sha1_value_lower)
+    string(TOLOWER "${sha1}" sha1_lower)
+    string(COMPARE EQUAL "${sha1_value_lower}" "${sha1_lower}" is_equal)
     if(NOT is_equal)
       hunter_internal_error(
           "Short SHA1 collision:"


### PR DESCRIPTION
* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **Yes**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **Yes**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **Yes**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **Yes**

This commit fixes the issue that SHA1 may not match due to different case sensitivity. For example, the `yaml-cpp` package is currently broken because of this reason.

        [hunter ** INTERNAL **] Short SHA1 collision:
        [hunter ** INTERNAL **]   956C2B5FBF5AA0EB8EF5EF890C0328B3AA357A13 (from /Users/usrname/.hunter/_Base/Download/yaml-cpp/0.6.2-0f9a586-p1/956c2b5/SHA1)
        [hunter ** INTERNAL **]   956c2b5fbf5aa0eb8ef5ef890c0328b3aa357a13
        [hunter ** INTERNAL **] [Directory:/Users/usrname/.hunter/_Base/Download/Hunter/0.23.249/d45d77d/Unpacked/cmake/projects/yaml-cpp]

        ------------------------------ ERROR -----------------------------
            https://hunter.readthedocs.io/en/latest/reference/errors/error.internal.html
        ------------------------------------------------------------------

        CMake Error at /Users/usrname/.hunter/_Base/Download/Hunter/0.23.249/d45d77d/Unpacked/cmake/modules/hunter_error_page.cmake:12 (message):
        Call Stack (most recent call first):
          /Users/usrname/.hunter/_Base/Download/Hunter/0.23.249/d45d77d/Unpacked/cmake/modules/hunter_internal_error.cmake:13 (hunter_error_page)
          /Users/usrname/.hunter/_Base/Download/Hunter/0.23.249/d45d77d/Unpacked/cmake/modules/hunter_make_directory.cmake:33 (hunter_internal_error)
          /Users/usrname/.hunter/_Base/Download/Hunter/0.23.249/d45d77d/Unpacked/cmake/modules/hunter_download.cmake:118 (hunter_make_directory)
          /Users/usrname/.hunter/_Base/Download/Hunter/0.23.249/d45d77d/Unpacked/cmake/projects/yaml-cpp/hunter.cmake:72 (hunter_download)
          /Users/usrname/.hunter/_Base/Download/Hunter/0.23.249/d45d77d/Unpacked/cmake/modules/hunter_add_package.cmake:62 (include)
          /Users/usrname/workspace/proj/src/shared/CMakeLists.txt:27 (hunter_add_package)


        -- Configuring incomplete, errors occurred!
        See also "/Users/usrname/workspace/proj/src/mac/build/CMakeFiles/CMakeOutput.log".