### PR TITLE
GIT_SUBMODULE fix: File not found .git/HEAD error

### DIFF
--- a/cmake/modules/hunter_pack_git_submodule.cmake
+++ b/cmake/modules/hunter_pack_git_submodule.cmake
@@ -120,7 +120,7 @@ function(hunter_pack_git_submodule)
   endif()
 
   set(head_file "${output}")
-  if(NOT EXISTS "${head_file}")
+  if(NOT EXISTS "${submodule_dir}/${head_file}")
     hunter_internal_error("File not found: '${head_file}'")
   endif()
   set_property(
@@ -163,7 +163,7 @@ function(hunter_pack_git_submodule)
   endif()
 
   set(ref_file "${output}")
-  if(NOT EXISTS "${ref_file}")
+  if(NOT EXISTS "${submodule_dir}/${ref_file}")
     hunter_internal_error("File not found: ${ref_file}")
   endif()
 


### PR DESCRIPTION

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **Yes**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **Yes**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **Yes**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **Yes**

This PR will fix a "File not found .git/HEAD" error, when you use `GIT_SUBMODULE` in `hunter_config()`
