### PR TITLE
Ignore more build folder and python venv folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,11 @@ cmake_install.cmake
 install_manifest.txt
 
 # CMake temp build directories
-_builds
-*/_builds
-*/*/_builds
-*/*/*/_builds
-*/*/*/*/_builds
+_build*
+*/_build*
+*/*/_build*
+*/*/*/_build*
+*/*/*/*/_build*
 
 _testing
 
@@ -33,3 +33,6 @@ _Base
 .vs
 .vscode
 CMakeSettings.json
+
+# Default vscode python virtual env folder
+env


### PR DESCRIPTION
ignore more build folder, originally only `_builds` folder, but I have `_build` folders for local testing. Now both are supported

Working with VSCode one can add the python plugin and a rst plugin to locally create the documentation. The default python virtual environment folder name in Visual Studio is `env`, so I added it