### PR TITLE
support debug runtime build of openssl on windows

### DIFF
--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows.cmake.in
@@ -68,6 +68,10 @@ else()
   set(do_ms do_ms.bat)
 endif()
 
+if(DEBUG_RUNTIME)
+  set(arch "debug-${arch}")
+endif()
+
 if(ASM_SUPPORT)
   hunter_add_package(NASM) # set NASM_ROOT
   set(opt "")

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows_1_1_plus.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows_1_1_plus.cmake.in
@@ -66,6 +66,10 @@ else()
   set(arch "VC-WIN32")
 endif()
 
+if(DEBUG_RUNTIME)
+  set(arch "debug-${arch}")
+endif()
+
 if(ASM_SUPPORT)
   hunter_add_package(NASM) # set NASM_ROOT
   set(opt "")


### PR DESCRIPTION
This adds a config option that works like the ASM_SUPPORT option to enable building openssl with debug runtime (e.g. `/MTd` switch).  The openssl build just needs a 'debug-' prefix on the arch name.  Usage in your config.cmake:
```
hunter_config(OpenSSL VERSION ${HUNTER_OpenSSL_VERSION}
 CMAKE_ARGS DEBUG_RUNTIME=ON
)
```
