### PR TITLE
Updates Boost’s default version to 1.72.0-p1.

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -37,7 +37,7 @@ if(MINGW)
   # https://github.com/boostorg/build/issues/301
   hunter_default_version(Boost VERSION 1.64.0)
 else()
-  hunter_default_version(Boost VERSION 1.72.0-p0)
+  hunter_default_version(Boost VERSION 1.72.0-p1)
 endif()
 
 hunter_default_version(BoostCompute VERSION 0.5-p0)


### PR DESCRIPTION
* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **Yes**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **Yes**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **Yes**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **Yes**

This commit updates Boost’s default version to 1.72.0-p1 to take advantage of the #180 fix.