### PR TITLE
[libarchive] add dependencies on compressor libraries

### DIFF
--- a/cmake/projects/libarchive/hunter.cmake
+++ b/cmake/projects/libarchive/hunter.cmake
@@ -21,17 +21,23 @@ hunter_add_version(
 hunter_configuration_types(libarchive CONFIGURATION_TYPES Release)
 hunter_pick_scheme(DEFAULT url_sha1_autotools)
 
+set(libarchive_dependencies
+    ZLIB
+    BZip2
+    lzma
+)
 hunter_cmake_args(
     libarchive
     CMAKE_ARGS
     PKGCONFIG_EXPORT_TARGETS=libarchive
     EXTRA_FLAGS=--without-iconv
+    DEPENDS_ON_PACKAGES=${libarchive_dependencies}
 )
 
 hunter_cacheable(libarchive)
 hunter_download(
     PACKAGE_NAME libarchive
-    PACKAGE_INTERNAL_DEPS_ID "1"
+    PACKAGE_INTERNAL_DEPS_ID "2"
     PACKAGE_UNRELOCATABLE_TEXT_FILES
     "lib/libarchive.la"
     "lib/pkgconfig/libarchive.pc"

--- a/examples/libarchive/boo.cpp
+++ b/examples/libarchive/boo.cpp
@@ -11,9 +11,9 @@ int main(int argc, char *argv[])
     char buf[32 * 1024];
     size_t used;
     auto arc = archive_write_new();
-    archive_write_add_filter_gzip(arc);
-    archive_write_set_format_pax_restricted(arc);
-    archive_write_open_memory(arc, buf, sizeof(buf), &used);
+    archive_write_set_format_zip(arc);
+    archive_write_zip_set_compression_deflate(arc);
+    archive_write_open_filename(arc, "test.zip");
     auto entry = archive_entry_new();
     archive_entry_set_pathname(entry, "hw.txt");
     archive_entry_set_size(entry, CONTENT.size());
@@ -21,6 +21,7 @@ int main(int argc, char *argv[])
     archive_entry_set_perm(entry, 0644);
     archive_write_header(arc, entry);
     archive_write_data(arc, CONTENT.c_str(), CONTENT.size());
+    archive_write_finish_entry(arc);
     archive_entry_free(entry);
     archive_write_close(arc);
     archive_write_free(arc);

--- a/scripts/pkgconfig-export-targets.cmake.in
+++ b/scripts/pkgconfig-export-targets.cmake.in
@@ -9,7 +9,7 @@ include(hunter_pkgconfig_export_target)
 
 hunter_pkgconfig_export_target("@PKG_CONFIG_MODULE@" "@PKG_GENERATE_SHARED@")
 
-foreach(_hunter_deps @DEPENDS_ON_PACKAGES@)
+foreach(_hunter_deps @DEPENDS_ON_PKGCONFIGS@)
   find_package("${_hunter_deps}" CONFIG REQUIRED)
 
   set_property(


### PR DESCRIPTION
This change adds missing compressor dependencies for libarchive.

I needed to change "pkgconfig-export-targets.cmake.in" since it was creating invalid dependencies.  It seems like it's the correct change to make here.  I'm not completely sure it won't break other things, though.  Is there a way to run the CI builds on everything?

<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **Yes**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **Yes**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **Yes**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **Yes**

---
<!--- END -->
