### PR TITLE
Fix example project link

### DIFF
--- a/docs/packages/pkg/Boost.rst
+++ b/docs/packages/pkg/Boost.rst
@@ -105,7 +105,7 @@ config file (``boost/config/user.hpp``):
   
   - `Boost-log <https://github.com/cpp-pm/hunter/blob/master/examples/Boost-log/CMakeLists.txt>`__
   
-  - `Boost-log-usingBoostConfig <https://github.com/cpp-pm/hunter/blob/master/examples/Boost-log-usingBoostConfig/CMakeLists.txt>`__
+  - `Boost-log-useBoostConfig <https://github.com/cpp-pm/hunter/blob/master/examples/Boost-log-useBoostConfig/CMakeLists.txt>`__
 
 
 Python


### PR DESCRIPTION
I've just fixed a broken link in the docs. I've clicked the new link once in the preview, but no further tests done. ;-)