### PR TITLE
fixed openssl build for ios

### DIFF
--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_ios.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_ios.cmake.in
@@ -106,14 +106,20 @@ foreach(variant @IPHONEOS_ARCHS@ @IPHONESIMULATOR_ARCHS@)
     set(SDK_ROOT ${IPHONEOS_SDK_ROOT})
   endif()
 
-  string(COMPARE EQUAL "${variant}" "arm" ios_cross)
-  if(ios_cross)
+  string(COMPARE EQUAL "${variant}" "arm" arm)
+  string(COMPARE EQUAL "${variant}" "armv7" armv7)
+  if(arm OR armv7)
     set(target "ios-cross")
   endif()
 
   string(COMPARE EQUAL "${variant}" "arm64" ios64_cross)
   if(ios64_cross)
     set(target "ios64-cross")
+  endif()
+
+  string(COMPARE EQUAL "${variant}" "i386" i386)
+  if(i386)
+    set(target "darwin-i386-cc")
   endif()
 
   string(COMPARE EQUAL "${variant}" "x86_64" x86_64)


### PR DESCRIPTION
iOS bitcode toolchain includes following architectures: armv7, arm64, i386, x86_64. armv7 and i386 are not handled in the scheme, so build fails. Fixed it.

<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---
<!--- END -->
