### PR TITLE
Update boost base url to fix bintray deprecation

### DIFF
--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -14,7 +14,7 @@ include(hunter_check_toolchain_definition)
 set(Boost_NO_SYSTEM_PATHS ON)
 
 # use base url for official boost releases
-set(_hunter_boost_base_url "https://dl.bintray.com/boostorg/release")
+set(_hunter_boost_base_url "https://boostorg.jfrog.io/artifactory/main/release")
 
 hunter_add_version(
     PACKAGE_NAME


### PR DESCRIPTION
Yesterday there was a scheduled downtime of Bintray and there will be one on the 26th of April as well.

For more details:
* https://github.com/boostorg/boost/issues/502
* https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
