### PR TITLE
Fix Apple Toolchain-ID changing on reconfigure

### DIFF
--- a/scripts/create-toolchain-info.cmake
+++ b/scripts/create-toolchain-info.cmake
@@ -142,6 +142,7 @@ foreach(x ${list_of_strings})
   endif()
 endforeach()
 
+list(SORT macros_list)
 list(REMOVE_DUPLICATES macros_list)
 string(REPLACE ";" "\n" macros_string "${macros_list}")
 


### PR DESCRIPTION
* Setting CMAKE_OSX_ARCHITECTURES to "arm64;x86_64" can cause output
  in either order so predefined macros must be alphanumerically
  sorted before putting into toolchain file.

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---

Fixes https://github.com/cpp-pm/hunter/issues/382. This will cause new Toolchain-IDs for all users who update Hunter versions past this PR.
