### PR TITLE
Update Boost to 1.76.0

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -37,7 +37,7 @@ if(MINGW)
   # https://github.com/boostorg/build/issues/301
   hunter_default_version(Boost VERSION 1.64.0)
 else()
-  hunter_default_version(Boost VERSION 1.75.0)
+  hunter_default_version(Boost VERSION 1.76.0)
 endif()
 
 hunter_default_version(BoostCompute VERSION 0.5-p0)

--- a/cmake/projects/Boost/generate.sh
+++ b/cmake/projects/Boost/generate.sh
@@ -3,13 +3,14 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
+# Try ./b2 --show-libraries to look for new libraries
 BOOST_LIBS="
     atomic
     chrono
-    context
     container
-    coroutine
+    context
     contract
+    coroutine
     date_time
     exception
     fiber
@@ -22,6 +23,7 @@ BOOST_LIBS="
     log
     math
     mpi
+    nowide
     program_options
     python
     random
@@ -33,6 +35,7 @@ BOOST_LIBS="
     test
     thread
     timer
+    type_erasure
     wave
 "
 

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -202,6 +202,17 @@ hunter_add_version(
     SHA1
     6109efd3bdd8b9220d7d85b5e125f7f28721b9a9
 )
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.76.0"
+    URL
+    "${_hunter_boost_base_url}/1.76.0/source/boost_1_76_0.tar.bz2"
+    SHA1
+    8064156508312dde1d834fec3dca9b11006555b6
+)
 # up until 1.63 sourcefourge was used
 set(_hunter_boost_base_url "https://downloads.sourceforge.net/project/boost/boost/")
 hunter_add_version(

--- a/cmake/projects/Boost/nowide/hunter.cmake
+++ b/cmake/projects/Boost/nowide/hunter.cmake
@@ -1,0 +1,22 @@
+# Copyright (c) 2013, Ruslan Baratov
+# All rights reserved.
+
+# !!! DO NOT PLACE HEADER GUARDS HERE !!!
+
+include(hunter_download)
+include(hunter_pick_scheme)
+
+hunter_pick_scheme(
+    DEFAULT
+    url_sha1_boost_library
+    IPHONEOS
+    url_sha1_boost_ios_library
+)
+
+hunter_download(
+    PACKAGE_NAME
+    Boost
+    PACKAGE_COMPONENT
+    nowide
+    PACKAGE_INTERNAL_DEPS_ID "49"
+)

--- a/cmake/projects/Boost/type_erasure/hunter.cmake
+++ b/cmake/projects/Boost/type_erasure/hunter.cmake
@@ -1,0 +1,22 @@
+# Copyright (c) 2013, Ruslan Baratov
+# All rights reserved.
+
+# !!! DO NOT PLACE HEADER GUARDS HERE !!!
+
+include(hunter_download)
+include(hunter_pick_scheme)
+
+hunter_pick_scheme(
+    DEFAULT
+    url_sha1_boost_library
+    IPHONEOS
+    url_sha1_boost_ios_library
+)
+
+hunter_download(
+    PACKAGE_NAME
+    Boost
+    PACKAGE_COMPONENT
+    type_erasure
+    PACKAGE_INTERNAL_DEPS_ID "49"
+)


### PR DESCRIPTION
* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**

---

It might be nice to remove the `hunter_default_version` hack in `default.cmake`, but someone interested in MINGW would need to look at that.