### PR TITLE
Pr.libjpegturbo

### DIFF
--- a/cmake/projects/libjpeg-turbo/hunter.cmake
+++ b/cmake/projects/libjpeg-turbo/hunter.cmake
@@ -42,7 +42,11 @@ hunter_add_version(
     40daf166fb943a6601190e6cfab0f48b2b674e58
 )
 
-hunter_pick_scheme(DEFAULT url_sha1_cmake)
+if (APPLE)
+  hunter_pick_scheme(DEFAULT url_sha1_cmake_libjpeg-turbo)
+else()
+  hunter_pick_scheme(DEFAULT url_sha1_cmake)
+endif()
 
 hunter_cmake_args(
     libjpeg-turbo

--- a/cmake/projects/libjpeg-turbo/schemes/url_sha1_cmake_libjpeg-turbo.cmake.in
+++ b/cmake/projects/libjpeg-turbo/schemes/url_sha1_cmake_libjpeg-turbo.cmake.in
@@ -1,0 +1,215 @@
+# Copyright (c) 2015, Ruslan Baratov
+# All rights reserved.
+
+cmake_minimum_required(VERSION 3.0)
+project(Hunter)
+
+include(ExternalProject) # ExternalProject_Add
+
+# Scheme for CMake projects
+
+# This is universal CMake scheme that will work for
+#   * single-configuration (`* Makefiles`)
+#     * cmake -DCMAKE_BUILD_TYPE=${configuration}
+#   * multi-configuration (Visual Studio, Xcode)
+#     * cmake -DCMAKE_CONFIGURATION_TYPES=...
+#     * cmake --build --config ${configuration}
+
+list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")
+
+include(hunter_status_debug)
+include(hunter_assert_not_empty_string)
+include(hunter_user_error)
+
+hunter_status_debug("Scheme: url_sha1_cmake")
+
+# Check preconditions
+hunter_assert_not_empty_string("@HUNTER_SELF@")
+hunter_assert_not_empty_string("@HUNTER_EP_NAME@")
+hunter_assert_not_empty_string("@HUNTER_PACKAGE_URL@")
+hunter_assert_not_empty_string("@HUNTER_PACKAGE_SHA1@")
+hunter_assert_not_empty_string("@HUNTER_PACKAGE_DOWNLOAD_DIR@")
+hunter_assert_not_empty_string("@HUNTER_PACKAGE_SOURCE_DIR@")
+hunter_assert_not_empty_string("@HUNTER_PACKAGE_INSTALL_PREFIX@")
+hunter_assert_not_empty_string("@HUNTER_PACKAGE_CONFIGURATION_TYPES@")
+hunter_assert_not_empty_string("@HUNTER_CACHE_FILE@")
+hunter_assert_not_empty_string("@HUNTER_ARGS_FILE@")
+hunter_assert_not_empty_string("@HUNTER_PACKAGE_LICENSE_DIR@")
+hunter_assert_not_empty_string("@CMAKE_GENERATOR@")
+hunter_assert_not_empty_string("${CMAKE_TOOLCHAIN_FILE}")
+hunter_assert_not_empty_string("@HUNTER_TLS_VERIFY@")
+
+if(IOS)
+  if(CMAKE_VERSION VERSION_LESS 3.5)
+    hunter_user_error("CMake 3.5+ version should be used for iOS toolchains")
+  endif()
+  string(COMPARE NOTEQUAL "${IPHONESIMULATOR_ARCHS}" "" has_simulator)
+  set(ios_opts "-DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=NO")
+  if(has_simulator)
+    list(APPEND ios_opts "-DCMAKE_IOS_INSTALL_COMBINED=YES")
+  endif()
+else()
+  set(ios_opts "")
+endif()
+
+# https://cmake.org/cmake/help/v3.4/release/3.4.html#modules
+# https://cmake.org/cmake/help/v3.4/module/ExternalProject.html
+if(CMAKE_VERSION VERSION_LESS 3.4)
+  set(uses_terminal "")
+else()
+  set(
+      uses_terminal
+      USES_TERMINAL_DOWNLOAD 1
+      USES_TERMINAL_UPDATE 1
+      USES_TERMINAL_CONFIGURE 1
+      USES_TERMINAL_BUILD 1
+      USES_TERMINAL_TEST 1
+      USES_TERMINAL_INSTALL 1
+  )
+endif()
+
+string(COMPARE NOTEQUAL "@HUNTER_JOBS_OPTION@" "" have_jobs)
+if(have_jobs)
+  string(COMPARE NOTEQUAL "@XCODE_VERSION@" "" is_xcode)
+  if(is_xcode)
+    set(jobs_option "-jobs" "@HUNTER_JOBS_OPTION@")
+  elseif("@MSVC_IDE@")
+    set(jobs_option "/maxcpucount:@HUNTER_JOBS_OPTION@")
+  else()
+    set(jobs_option "-j@HUNTER_JOBS_OPTION@")
+  endif()
+else()
+  set(jobs_option "")
+endif()
+
+set(previous_project "")
+
+if("@HUNTER_PACKAGE_LOG_BUILD@")
+  set(log_build 1)
+else()
+  set(log_build 0)
+endif()
+
+if("@HUNTER_PACKAGE_LOG_INSTALL@" OR "@HUNTER_SUPPRESS_LIST_OF_FILES@")
+  set(log_install 1)
+else()
+  set(log_install 0)
+endif()
+
+string(COMPARE EQUAL "@HUNTER_PACKAGE_PROTECTED_SOURCES@" "" is_empty)
+if(is_empty)
+  set(http_credentials "")
+else()
+  set(
+      http_credentials
+      HTTP_USERNAME "@HUNTER_PACKAGE_HTTP_USERNAME@"
+      HTTP_PASSWORD "@HUNTER_PACKAGE_HTTP_PASSWORD@"
+  )
+endif()
+
+string(COMPARE NOTEQUAL "${CMAKE_MAKE_PROGRAM}" "" has_make)
+if(has_make)
+  set(make_args "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}")
+else()
+  set(make_args "")
+endif()
+
+string(COMPARE EQUAL "${CMAKE_CFG_INTDIR}" "." is_single)
+
+set(configuration_types "@HUNTER_PACKAGE_CONFIGURATION_TYPES@")
+list(LENGTH configuration_types len)
+if(len EQUAL "1")
+  set(no_postfix TRUE)
+else()
+  set(no_postfix FALSE)
+endif()
+
+foreach(configuration ${configuration_types})
+  # All configurations use the same URL which will be downloaded only once
+  # i.e. overhead only for unpacking archive + no files from the previous
+  # build will be left in case package do some insource modification (wrongly)
+  string(TOUPPER "${configuration}" configuration_upper)
+  string(COMPARE EQUAL "${configuration_upper}" "RELEASE" is_release)
+  set(postfix_name "CMAKE_${configuration_upper}_POSTFIX")
+  string(COMPARE EQUAL "${${postfix_name}}" "" is_empty)
+
+  if(NOT is_release AND is_empty)
+    set("${postfix_name}" "-${configuration}")
+  endif()
+
+  if(no_postfix)
+    set("${postfix_name}" "")
+  endif()
+
+  set(current_project "@HUNTER_EP_NAME@-${configuration}")
+
+  if(is_single)
+    set(build_type_opts "-DCMAKE_BUILD_TYPE=${configuration}")
+  else()
+    set(build_type_opts "-DCMAKE_CONFIGURATION_TYPES=${configuration}")
+  endif()
+
+  ExternalProject_Add(
+      "${current_project}"
+      URL
+      @HUNTER_PACKAGE_URL@
+      URL_HASH
+      SHA1=@HUNTER_PACKAGE_SHA1@
+      ${http_credentials}
+      DOWNLOAD_DIR
+      "@HUNTER_PACKAGE_DOWNLOAD_DIR@"
+      TLS_VERIFY
+      "@HUNTER_TLS_VERIFY@"
+      SOURCE_DIR
+      "@HUNTER_PACKAGE_SOURCE_DIR@"
+      INSTALL_DIR
+      "@HUNTER_PACKAGE_INSTALL_PREFIX@"
+          # not used, just avoid creating Install/<name> empty directory
+      SOURCE_SUBDIR
+      "@HUNTER_PACKAGE_SOURCE_SUBDIR@"
+      BUILD_COMMAND
+          # Separate build and install stage so we can suppress install log
+          # which may consist of a long list of files
+          "@CMAKE_COMMAND@"
+          --build .
+          --config ${configuration}
+          --
+          ${jobs_option}
+      CMAKE_ARGS
+      "-G@CMAKE_GENERATOR@"
+      "-C@HUNTER_CACHE_FILE@"
+      "-C@HUNTER_ARGS_FILE@"
+      "-D${postfix_name}=${${postfix_name}}"
+      "${build_type_opts}"
+      "-DCMAKE_INSTALL_PREFIX=@HUNTER_PACKAGE_INSTALL_PREFIX@"
+      "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+      "${make_args}"
+      ${ios_opts}
+      INSTALL_COMMAND
+          "@CMAKE_COMMAND@"
+          --build .
+          --target install
+          --config ${configuration}
+        COMMAND # Copy license files
+          "@CMAKE_COMMAND@"
+          "-C@HUNTER_ARGS_FILE@" # for 'HUNTER_INSTALL_LICENSE_FILES'
+          "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+          "-Ddstdir=@HUNTER_PACKAGE_LICENSE_DIR@"
+          -P
+          "@HUNTER_SELF@/scripts/try-copy-license.cmake"
+      LOG_BUILD ${log_build}
+      LOG_INSTALL ${log_install}
+      ${uses_terminal}
+  )
+
+  # Each external project must depends on previous one since they all use
+  # the same building directory
+  string(COMPARE EQUAL "${previous_project}" "" is_empty)
+  if(NOT is_empty)
+    add_dependencies(
+        "${current_project}"
+        "${previous_project}"
+    )
+  endif()
+  set(previous_project "${current_project}")
+endforeach()

--- a/cmake/projects/libjpeg-turbo/schemes/url_sha1_cmake_libjpeg-turbo.cmake.in
+++ b/cmake/projects/libjpeg-turbo/schemes/url_sha1_cmake_libjpeg-turbo.cmake.in
@@ -19,6 +19,7 @@ list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")
 
 include(hunter_status_debug)
 include(hunter_assert_not_empty_string)
+include(hunter_unsetvar)
 include(hunter_user_error)
 
 hunter_status_debug("Scheme: url_sha1_cmake")
@@ -82,8 +83,6 @@ else()
   set(jobs_option "")
 endif()
 
-set(previous_project "")
-
 if("@HUNTER_PACKAGE_LOG_BUILD@")
   set(log_build 1)
 else()
@@ -124,6 +123,13 @@ else()
   set(no_postfix FALSE)
 endif()
 
+set(configure_architectures @CMAKE_OSX_ARCHITECTURES@)
+
+if(NOT configure_architectures)
+  hunter_status_debug("Using default macOS architecture: x86_64")
+  set(configure_architectures "x86_64")
+endif()
+
 foreach(configuration ${configuration_types})
   # All configurations use the same URL which will be downloaded only once
   # i.e. overhead only for unpacking archive + no files from the previous
@@ -149,13 +155,86 @@ foreach(configuration ${configuration_types})
     set(build_type_opts "-DCMAKE_CONFIGURATION_TYPES=${configuration}")
   endif()
 
-  ExternalProject_Add(
+  hunter_unsetvar(jpeg_libraries)
+  hunter_unsetvar(turbojpeg_libraries)
+
+  foreach(arch ${configure_architectures})
+    list(GET configure_architectures 0 first_architecture)
+    if (first_architecture STREQUAL arch)
+      # install to main dir
+      set(install_location "@HUNTER_PACKAGE_INSTALL_PREFIX@")
+    else()
+      # install to temp dir
+      set(install_location "@HUNTER_PACKAGE_BUILD_DIR@/${arch}-install")
+    endif()
+
+    list(APPEND jpeg_libraries "${install_location}/lib/libjpeg${${postfix_name}}.a")
+    list(APPEND turbojpeg_libraries "${install_location}/lib/libturbojpeg${${postfix_name}}.a")
+
+    ExternalProject_Add(
+        "${current_project}-${arch}"
+        URL
+        @HUNTER_PACKAGE_URL@
+        URL_HASH
+        SHA1=@HUNTER_PACKAGE_SHA1@
+        ${http_credentials}
+        DOWNLOAD_DIR
+        "@HUNTER_PACKAGE_DOWNLOAD_DIR@"
+        TLS_VERIFY
+        "@HUNTER_TLS_VERIFY@"
+        SOURCE_DIR
+        "@HUNTER_PACKAGE_SOURCE_DIR@"
+        INSTALL_DIR
+        "${install_location}"
+            # not used, just avoid creating Install/<name> empty directory
+        SOURCE_SUBDIR
+        "@HUNTER_PACKAGE_SOURCE_SUBDIR@"
+        BUILD_COMMAND
+            # Separate build and install stage so we can suppress install log
+            # which may consist of a long list of files
+            "@CMAKE_COMMAND@"
+            --build .
+            --config ${configuration}
+            --
+            ${jobs_option}
+        CMAKE_ARGS
+        "-G@CMAKE_GENERATOR@"
+        "-C@HUNTER_CACHE_FILE@"
+        "-C@HUNTER_ARGS_FILE@"
+        "-D${postfix_name}=${${postfix_name}}"
+        "${build_type_opts}"
+        "-DCMAKE_INSTALL_PREFIX=${install_location}"
+        "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+        "${make_args}"
+        ${ios_opts}
+        "-DCMAKE_OSX_ARCHITECTURES=${arch}"
+        INSTALL_COMMAND
+            "@CMAKE_COMMAND@"
+            --build .
+            --target install
+            --config ${configuration}
+          COMMAND # Copy license files
+            "@CMAKE_COMMAND@"
+            "-C@HUNTER_ARGS_FILE@" # for 'HUNTER_INSTALL_LICENSE_FILES'
+            "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
+            "-Ddstdir=@HUNTER_PACKAGE_LICENSE_DIR@"
+            -P
+            "@HUNTER_SELF@/scripts/try-copy-license.cmake"
+        LOG_BUILD ${log_build}
+        LOG_INSTALL ${log_install}
+        ${uses_terminal}
+    )
+
+  endforeach()
+
+  list(LENGTH configure_architectures configure_architectures_length)
+  if (NOT ${configure_architectures_length} EQUAL 1)
+    # fuse all libraries with 'lipo'
+    # libjpeg-turbo does not support multiple arch builds due to asm requirements
+    ExternalProject_Add(
       "${current_project}"
-      URL
-      @HUNTER_PACKAGE_URL@
-      URL_HASH
-      SHA1=@HUNTER_PACKAGE_SHA1@
-      ${http_credentials}
+      DOWNLOAD_COMMAND
+      "@CMAKE_COMMAND@" -E echo "Dummy download command"
       DOWNLOAD_DIR
       "@HUNTER_PACKAGE_DOWNLOAD_DIR@"
       TLS_VERIFY
@@ -165,51 +244,39 @@ foreach(configuration ${configuration_types})
       INSTALL_DIR
       "@HUNTER_PACKAGE_INSTALL_PREFIX@"
           # not used, just avoid creating Install/<name> empty directory
-      SOURCE_SUBDIR
-      "@HUNTER_PACKAGE_SOURCE_SUBDIR@"
+      CONFIGURE_COMMAND
+      "@CMAKE_COMMAND@" -E echo "Dummy configure command"
       BUILD_COMMAND
-          # Separate build and install stage so we can suppress install log
-          # which may consist of a long list of files
-          "@CMAKE_COMMAND@"
-          --build .
-          --config ${configuration}
-          --
-          ${jobs_option}
-      CMAKE_ARGS
-      "-G@CMAKE_GENERATOR@"
-      "-C@HUNTER_CACHE_FILE@"
-      "-C@HUNTER_ARGS_FILE@"
-      "-D${postfix_name}=${${postfix_name}}"
-      "${build_type_opts}"
-      "-DCMAKE_INSTALL_PREFIX=@HUNTER_PACKAGE_INSTALL_PREFIX@"
-      "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
-      "${make_args}"
-      ${ios_opts}
+      "@CMAKE_COMMAND@" -E echo "Dummy build command"
       INSTALL_COMMAND
-          "@CMAKE_COMMAND@"
-          --build .
-          --target install
-          --config ${configuration}
-        COMMAND # Copy license files
-          "@CMAKE_COMMAND@"
-          "-C@HUNTER_ARGS_FILE@" # for 'HUNTER_INSTALL_LICENSE_FILES'
-          "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@"
-          "-Ddstdir=@HUNTER_PACKAGE_LICENSE_DIR@"
-          -P
-          "@HUNTER_SELF@/scripts/try-copy-license.cmake"
-      LOG_BUILD ${log_build}
-      LOG_INSTALL ${log_install}
-      ${uses_terminal}
-  )
-
-  # Each external project must depends on previous one since they all use
-  # the same building directory
-  string(COMPARE EQUAL "${previous_project}" "" is_empty)
-  if(NOT is_empty)
-    add_dependencies(
-        "${current_project}"
-        "${previous_project}"
+      lipo
+      -create
+      ${jpeg_libraries}
+      -o
+      "@HUNTER_PACKAGE_INSTALL_PREFIX@/lib/libjpeg${${postfix_name}}.a"
+      COMMAND
+      lipo
+      -create
+      ${turbojpeg_libraries}
+      -o
+      "@HUNTER_PACKAGE_INSTALL_PREFIX@/lib/libturbojpeg${${postfix_name}}.a"
+      # Extra commands
+      ${extra_install_commands}
+      COMMAND # Copy license files
+        "@CMAKE_COMMAND@"
+        "-C@HUNTER_ARGS_FILE@" # for 'HUNTER_INSTALL_LICENSE_FILES'
+        "-Dsrcdir=@HUNTER_PACKAGE_SOURCE_DIR@}"
+        "-Ddstdir=@HUNTER_PACKAGE_LICENSE_DIR@"
+        -P
+        "@HUNTER_SELF@/scripts/try-copy-license.cmake"
     )
+
+    foreach(arch ${configure_architectures})
+      add_dependencies(
+        "${current_project}"
+        "${current_project}-${arch}"
+      )
+    endforeach()
   endif()
-  set(previous_project "${current_project}")
+
 endforeach()


### PR DESCRIPTION
* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**

* This update will fix a few toolchains.
  - universal2

---

libjpeg-turbo (as of v2.1.0) supports `CMAKE_OSX_ARCHITECTURES`, however due to it using lots of ASM stuff it only supports one at once (i.e `arm64` is fine, `arm64;x86_64` is not).

I have put this in as 2 commits to make it easier to check out. Commit 1 makes a copy of `url_sha1_cmake.cmake` for libjpeg-turbo and commit 2 alters it to build once for each OSX_ARCHITECTURE and lipo them.