### PR TITLE
add gtest version 1.11.0

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -70,7 +70,7 @@ hunter_default_version(GSL VERSION 2.1.0-p2)
 if(MSVC80)
   hunter_default_version(GTest VERSION 1.7.0-hunter-6)
 else()
-  hunter_default_version(GTest VERSION 1.10.0)
+  hunter_default_version(GTest VERSION 1.11.0)
 endif()
 
 hunter_default_version(HalideIR VERSION 0.0-32057b5-p0)

--- a/cmake/projects/GTest/hunter.cmake
+++ b/cmake/projects/GTest/hunter.cmake
@@ -282,7 +282,7 @@ hunter_add_version(
     7b100bb68db8df1060e178c495f3cbe941c9b058
 )
 
-if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0)
+if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0 OR HUNTER_GTest_VERSION VERSION_GREATER_EQUAL 1.11.0)
   set(_gtest_license "LICENSE")
 else()
   set(_gtest_license "googletest/LICENSE")

--- a/cmake/projects/GTest/hunter.cmake
+++ b/cmake/projects/GTest/hunter.cmake
@@ -271,6 +271,17 @@ hunter_add_version(
     06a1f667f200ff94d38b608e44c3c8061c7b8f2f
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    GTest
+    VERSION
+    "1.11.0"
+    URL
+    "https://github.com/google/googletest/archive/release-1.11.0.tar.gz"
+    SHA1
+    7b100bb68db8df1060e178c495f3cbe941c9b058
+)
+
 if(HUNTER_GTest_VERSION VERSION_LESS 1.8.0)
   set(_gtest_license "LICENSE")
 else()


### PR DESCRIPTION
* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **Yes**

This updates GTest to Version 1.11.0 which, most notably, also successfully compiles with Gcc-11 :)