### PR TITLE
fix find_python script for cmake >= 3.15

### DIFF
--- a/scripts/find_python.cmake
+++ b/scripts/find_python.cmake
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 if(DEFINED ENV{HUNTER_PYTHON_LOCATION})
   set(Python_ROOT_DIR $ENV{HUNTER_PYTHON_LOCATION})
+  set(Python_FIND_STRATEGY LOCATION)
 endif()
 
 find_package(Python COMPONENTS Interpreter QUIET)


### PR DESCRIPTION
<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

For CMake >= 3.15 wrong version of Python is found in the find_python.cmake script
this leads to error in ci testing on cache upload as 'requests' module is not found
https://github.com/cpp-pm/hunter/runs/2738382465#step:7:4079

see: https://cmake.org/cmake/help/v3.15/policy/CMP0094.html#policy:CMP0094

---
<!--- END -->
