### PR TITLE
don't upload cache if password is not set

### DIFF
--- a/.github/workflows/ci/build.cmd
+++ b/.github/workflows/ci/build.cmd
@@ -45,7 +45,7 @@ if not "%TOOLCHAIN:vs-=%"=="%TOOLCHAIN%" set HUNTER_BINARY_DIR=C:\__BIN
 :: Add msbuild to PATH (for vs-14 toolchain, GitHub windows-2016 runner doesn't have VS 2015)
 if "%TOOLCHAIN:~0,5%"=="vs-14" set PATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin;%PATH%
 
-if "%BRANCH_NAME%" == "master" (
+if "%BRANCH_NAME%" == "master" if not "%GITHUB_USER_PASSWORD%" == "" (
     python jenkins.py --upload
 ) else (
     python jenkins.py

--- a/.github/workflows/ci/build.sh
+++ b/.github/workflows/ci/build.sh
@@ -35,7 +35,7 @@ if [[ "$TOOLCHAIN" =~ "osx-11-0" ]]; then
 fi
 
 # Run build script
-if [[ "$BRANCH_NAME" == "master" ]]; then
+if [[ "$BRANCH_NAME" == "master" && ! -z "$GITHUB_USER_PASSWORD" ]]; then
     python jenkins.py --upload
 else
     python jenkins.py


### PR DESCRIPTION
<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

Helps to mitigate problem with manual workflow run in forked repo (as it's done on the master branch).
Without this change manual package test result in error:
[hunter ** FATAL ERROR **] Upload: PASSWORD is missing

---
<!--- END -->
