### PR TITLE
Fix compilation on windows msvc and ninja

### DIFF
--- a/cmake/projects/OpenSSL/ep-stages/configure_1_1_plus.cmake.in
+++ b/cmake/projects/OpenSSL/ep-stages/configure_1_1_plus.cmake.in
@@ -12,6 +12,20 @@ if("@openssl_dir@" STREQUAL "")
   message(FATAL_ERROR "openssl_dir is empty")
 endif()
 
+if("@MSVC@")
+  # Unset as we are already in a msvc environment 
+  # and the openssl perl script will figure things out.
+  # The created variable content by CMake is unqouted and will cause issues
+  unset(ENV{CC})
+  unset(ENV{CXX})
+  unset(ENV{RC})
+  unset(ENV{AR})
+  unset(ENV{RUNLIB})
+else()
+  set(log_opts "")
+endif()
+
+
 execute_process(COMMAND
   perl Configure @arch@ @opt@ @shared@ "--prefix=@openssl_install_dir@" "--openssldir=@openssl_dir@" RESULT_VARIABLE result)
 

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows_1_1_plus.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows_1_1_plus.cmake.in
@@ -104,6 +104,7 @@ set(openssl_install_dir "@HUNTER_PACKAGE_INSTALL_PREFIX@")
 #   * opt
 #   * shared
 #   * NASM_ROOT
+#   * MSVC
 configure_file(
     "@HUNTER_PACKAGE_SETUP_DIR@/ep-stages/configure_1_1_plus.cmake.in"
     "@HUNTER_PACKAGE_BUILD_DIR@/configure_1_1_plus.cmake"


### PR DESCRIPTION
* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**

* This update will fix a toolchain.
  - ninja-vs-15-2017-win64-cxx17 


The issue boils down that `url_sha1_openssl_windows_1_1_plus.cmake` calls `configure_1_1_plus.cmake`
And CMake populates `CXX`,  `CC` and other environment variables.

The build fails because, the content of these variables are absolute file paths **without any quotes** and they are **not escaped**.
But openssl will use them and fails upon calling them.

The same goes for many other projects (e.g. Boost during b2) and I created this PR to show it for openssl* and get a conversation going.
My guess is that CMake actually sets these variables wrong, or Hunter should set them manually.


**So I'm hoping for some feedback on how this might be solved in a better more general way.**




*) unfortunately since the last version of hunter, the CI does not run the builds anymore.






