### PR TITLE
Update Boost to v1.77.0

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -37,7 +37,7 @@ if(MINGW)
   # https://github.com/boostorg/build/issues/301
   hunter_default_version(Boost VERSION 1.64.0)
 else()
-  hunter_default_version(Boost VERSION 1.76.0)
+  hunter_default_version(Boost VERSION 1.77.0)
 endif()
 
 hunter_default_version(BoostCompute VERSION 0.5-p0)

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -213,6 +213,17 @@ hunter_add_version(
     SHA1
     8064156508312dde1d834fec3dca9b11006555b6
 )
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.77.0"
+    URL
+    "${_hunter_boost_base_url}/1.77.0/source/boost_1_77_0.tar.bz2"
+    SHA1
+    0cb4f947d094fc311e13ffacaff00418130ef5ef
+)
 # up until 1.63 sourcefourge was used
 set(_hunter_boost_base_url "https://downloads.sourceforge.net/project/boost/boost/")
 hunter_add_version(


### PR DESCRIPTION
 * I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html) step by step carefully. **Yes**

upstream release page: https://www.boost.org/users/history/version_1_77_0.html