### PR TITLE
Update abseil to 20210324.2

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -174,7 +174,7 @@ hunter_default_version(ZMQPP VERSION 4.2.0-p0)
 hunter_default_version(ZeroMQ VERSION 4.2.3-p1)
 hunter_default_version(Zug VERSION 0.0.1-be20cae)
 
-hunter_default_version(abseil VERSION 20200923.2)
+hunter_default_version(abseil VERSION 20210324.2)
 hunter_default_version(acf VERSION 0.1.14)
 hunter_default_version(actionlib VERSION 1.11.13-p0)
 hunter_default_version(aes VERSION 0.0.1-p1)

--- a/cmake/projects/abseil/hunter.cmake
+++ b/cmake/projects/abseil/hunter.cmake
@@ -31,6 +31,17 @@ hunter_add_version(
     1dd3f0a937c3678437646d26ca6784bd6a9b2b26
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    abseil
+    VERSION
+    20210324.2
+    URL
+    "https://github.com/abseil/abseil-cpp/archive/20210324.2.tar.gz"
+    SHA1
+    2d46ae096bfbdab19de1d65079b95e0fae9efe2e
+)
+
 hunter_cmake_args(
     abseil
     CMAKE_ARGS


### PR DESCRIPTION
* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**

[CI build](https://github.com/tgval/hunter/actions/runs/1233508042) - See all toolchains pass, except for `analyze-cxx17` on ubuntu 20.04. I've looked at previous release [test](https://github.com/cpp-pm/hunter/pull/317/checks?check_run_id=1511635180) which seems to indicate the analyze toolchain was also not successful. 


