### PR TITLE
Fix autotools when using hunter download server

### DIFF
--- a/cmake/modules/hunter_autotools_project.cmake
+++ b/cmake/modules/hunter_autotools_project.cmake
@@ -73,7 +73,6 @@ function(hunter_autotools_project target_name)
   set(optional_params)
   set(one_value_params
       HUNTER_SELF
-      URL
       URL_HASH
       DOWNLOAD_DIR
       SOURCE_DIR
@@ -88,6 +87,7 @@ function(hunter_autotools_project target_name)
       BOOTSTRAP
   )
   set(multi_value_params
+      URL
       PACKAGE_CONFIGURATION_TYPES
       EXTRA_FLAGS
       PATCH_COMMAND


### PR DESCRIPTION
The introduction of HUNTER_DOWNLOAD_SERVER broke the autotools scheme
because the scheme expected exactly one URL.

To fix that, teach autotools that URL is a multi value parameter.

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**
