### PR TITLE
Reduced required CMake version

### DIFF
--- a/scripts/find_python.cmake
+++ b/scripts/find_python.cmake
@@ -1,14 +1,24 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.0)
 
-if(DEFINED ENV{HUNTER_PYTHON_LOCATION})
-  set(Python_ROOT_DIR $ENV{HUNTER_PYTHON_LOCATION})
-  set(Python_FIND_STRATEGY LOCATION)
+if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
+  find_package(PythonInterp 3 QUIET)
+  if(NOT PYTHONINTERP_FOUND)
+    message(FATAL_ERROR "Python not found")
+  endif()
+  message(${PYTHON_EXECUTABLE})
+else()
+  cmake_minimum_required(VERSION 3.12)
+
+  if(DEFINED ENV{HUNTER_PYTHON_LOCATION})
+    set(Python_ROOT_DIR $ENV{HUNTER_PYTHON_LOCATION})
+    set(Python_FIND_STRATEGY LOCATION)
+  endif()
+
+  find_package(Python COMPONENTS Interpreter QUIET)
+
+  if(NOT Python_Interpreter_FOUND)
+    message(FATAL_ERROR "Python not found")
+  endif()
+
+  message(${Python_EXECUTABLE})
 endif()
-
-find_package(Python COMPONENTS Interpreter QUIET)
-
-if(NOT Python_Interpreter_FOUND)
-  message(FATAL_ERROR "Python not found")
-endif()
-
-message(${Python_EXECUTABLE})

--- a/scripts/link-all.cmake
+++ b/scripts/link-all.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.0)
 
 string(COMPARE EQUAL "${HUNTER_INSTALL_PREFIX}" "" is_empty)
 if(is_empty)


### PR DESCRIPTION
* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[No]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---

Closes: https://github.com/cpp-pm/hunter/issues/367

As stated in the issue, the change https://github.com/cpp-pm/hunter/commit/f43d5f3e2ecf7e0094f4b25f85ffb221788f582d bumped required CMake version to `3.12`. This reverts it by using previous behavior for version less than `3.12` and new behavior otherwise. 

(PR just combines the removed and added bits from the https://github.com/cpp-pm/hunter/commit/f43d5f3e2ecf7e0094f4b25f85ffb221788f582d commit)

Tested on our project (min 3.10.x), which was using an old Hunter version before the version bump

Question: should Hunter have its CI run with latest and minimum supported CMake version to keep this behavior going forward? There might be some projects that require higher versions of CMake and those could still be left as exceptions, but this change limited any use of Hunter, so might make sense just for the base Hunter to run the CI with minimum CMake version as well