### PR TITLE
docs: Boost: mention BOOST_BUILD_DYNAMIC_VSRUNTIME

### DIFF
--- a/docs/packages/pkg/Boost.rst
+++ b/docs/packages/pkg/Boost.rst
@@ -107,6 +107,11 @@ config file (``boost/config/user.hpp``):
   
   - `Boost-log-useBoostConfig <https://github.com/cpp-pm/hunter/blob/master/examples/Boost-log-useBoostConfig/CMakeLists.txt>`__
 
+- Option ``BOOST_BUILD_DYNAMIC_VSRUNTIME=OFF`` use on Windows to build the boost libraries with the static runtime.
+
+  Should be used together with ``USE_CONFIG_FROM_BOOST=ON``.
+  Otherwise the generated library filenames won't be found by the provided ``FindBoost.cmake`` module.
+
 
 Python
 ------


### PR DESCRIPTION
<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---
<!--- END -->

document a flag that can be used on Windows builds of Boost libraries to link the libraries against the static runtime libraries.