### PR TITLE
szip: Fix example compile with size_t and extern "C"

### DIFF
--- a/examples/szip/CMakeLists.txt
+++ b/examples/szip/CMakeLists.txt
@@ -14,4 +14,4 @@ hunter_add_package(szip)
 find_package(szip REQUIRED)
 
 add_executable(foo foo.cpp)
-target_link_libraries(foo szip::szip)
+target_link_libraries(foo PRIVATE szip::szip)

--- a/examples/szip/foo.cpp
+++ b/examples/szip/foo.cpp
@@ -1,6 +1,14 @@
+#include <cstddef> // szlib.h uses size_t, but doesn't include stddef.h, workaround that
+extern "C" {
+// szlib.h is a C-library, but the header doesn't handle C++, so do it for the lib
+// otherwise the functions (for example SZ_encoder_enabled()) will not be found
 #include <szlib.h>
+}
+#include <iostream>
 
 int main()
 {
+   std::cout << "SZLIB_VERSION: " << SZLIB_VERSION << std::endl;
+   std::cout << "SZ_encoder_eabled: " << SZ_encoder_enabled() << std::endl;
    return 0;
 }


### PR DESCRIPTION
szlib is compiled as a pure C static library. So there is no C++
name-mangling done. When including the `szlib.h` header into a C++
project the compiler assumes the header to be a C++ header and does
name-mangling. This results in linker errors when using szip-functions.

The second problem is the usage of `size_t` inside `szlib.h` whithout a
`stddef.h` include. Probably some other include provided the `size_t` in
the past, but maybe the stdlib changed and this missing include is
surfacing now.
