### PR TITLE
Update CLI11 default args

### DIFF
--- a/cmake/projects/CLI11/hunter.cmake
+++ b/cmake/projects/CLI11/hunter.cmake
@@ -171,6 +171,9 @@ hunter_cmake_args(
     CLI11_TESTING=OFF
     CLI11_EXAMPLES=OFF
     CLI11_SINGLE_FILE=OFF
+    CLI11_BUILD_DOCS=OFF
+    CLI11_BUILD_TESTS=OFF
+    CLI11_BUILD_EXAMPLES=OFF
 )
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)


### PR DESCRIPTION
The args were changed in 1.9.0 so update the args
leave the old args for backwards compatibility

<!--- Use this part of template if you're adding new package. Remove the rest. -->
<!--- BEGIN -->

* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/create/cmake.html)
  step by step carefully. **Yes**
