### PR TITLE
More intelligent build arch default in macos scheme for OpenSSL

### DIFF
--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_macos.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_macos.cmake.in
@@ -36,8 +36,8 @@ set(configure_command "./Configure")
 set(configure_architectures @CMAKE_OSX_ARCHITECTURES@)
 
 if(NOT configure_architectures)
-  hunter_status_debug("Using default macOS architecture: x86_64")
-  set(configure_architectures "x86_64")
+  hunter_status_debug("Using CMAKE_SYSTEM_PROCESSOR to set default macOS architecture to: @CMAKE_SYSTEM_PROCESSOR@")
+  set(configure_architectures "@CMAKE_SYSTEM_PROCESSOR@")
 endif()
 
 # OpenSSL appends the version number differently by version


### PR DESCRIPTION
The MacOS scheme for OpenSSL defaults to "x86_64" if CMAKE_OSX_ARCHITECTURES is not set. This can result in a broken build on M1 (arm64) Macs if the CMake configuration depends on OpenSSL via Hunter. This pull request replaces the "x86_64" default with CMAKE_SYSTEM_PROCESSOR.

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**
