### PR TITLE
docs: move to `html_css_files` as `add_stylesheet` is deprecated/removed

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,9 +169,12 @@ html_static_path = ['_static', 'rtfd-css/docs/rtfd-css']
 
 # Add custom .css files
 # https://github.com/snide/sphinx_rtd_theme/issues/117#issuecomment-41571653
-def setup(app):
-   app.add_stylesheet("custom.css")
-   app.add_stylesheet("rtfd-css.css")
+# 2022-06-22: move to `html_css_files` as `add_stylesheet` is deprecated/removed
+#   https://github.com/sphinx-doc/sphinx/issues/9683#issuecomment-932878909
+html_css_files = [
+   "custom.css",
+   "rtfd-css.css",
+]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
With Sphinx 4 the function `add_stylesheet()` was temporarily removed
and added back in in newer versions of Sphinx. As alternative the
`html_css_files` variable is mentioned, which is available since
Sphinx 1.8.

The `python3-sphinx` package with version `4.3.2-1` from Ubuntu 22.04
jammy doesn't have the `add_stylesheet()` API, which breaks
documentation generation on said platform.

https://github.com/sphinx-doc/sphinx/issues/9683#issuecomment-932878909
