### PR TITLE
docs: fmt: add formatter to fix spelling error

### DIFF
--- a/docs/packages/pkg/fmt.rst
+++ b/docs/packages/pkg/fmt.rst
@@ -1,6 +1,7 @@
 .. spelling::
 
     fmt
+    formatter
 
 .. index:: logging ; fmt
 


### PR DESCRIPTION
On Ubuntu 22.04 jammy with Sphinx 4.3.0 and spell checker 7.2.1 the word `formatter` in the `fmt.rst` package documentation is flagged as an spelling mistake.

Explicitly add the word to silence the warning.
