### PR TITLE
Boost: libs: pass BOOST_USE_WINAPI_VERSION as define

### DIFF
--- a/cmake/projects/Boost/atomic/hunter.cmake
+++ b/cmake/projects/Boost/atomic/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     atomic
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/chrono/hunter.cmake
+++ b/cmake/projects/Boost/chrono/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     chrono
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/container/hunter.cmake
+++ b/cmake/projects/Boost/container/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     container
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/context/hunter.cmake
+++ b/cmake/projects/Boost/context/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     context
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/contract/hunter.cmake
+++ b/cmake/projects/Boost/contract/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     contract
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/coroutine/hunter.cmake
+++ b/cmake/projects/Boost/coroutine/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     coroutine
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/date_time/hunter.cmake
+++ b/cmake/projects/Boost/date_time/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     date_time
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/exception/hunter.cmake
+++ b/cmake/projects/Boost/exception/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     exception
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/fiber/hunter.cmake
+++ b/cmake/projects/Boost/fiber/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     fiber
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/filesystem/hunter.cmake
+++ b/cmake/projects/Boost/filesystem/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     filesystem
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/graph/hunter.cmake
+++ b/cmake/projects/Boost/graph/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/graph_parallel/hunter.cmake
+++ b/cmake/projects/Boost/graph_parallel/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     graph_parallel
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/hunter.cmake.in
+++ b/cmake/projects/Boost/hunter.cmake.in
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     boost_component
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/iostreams/hunter.cmake
+++ b/cmake/projects/Boost/iostreams/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     iostreams
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/json/hunter.cmake
+++ b/cmake/projects/Boost/json/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     json
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/locale/hunter.cmake
+++ b/cmake/projects/Boost/locale/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     locale
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/log/hunter.cmake
+++ b/cmake/projects/Boost/log/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     log
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/math/hunter.cmake
+++ b/cmake/projects/Boost/math/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     math
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/mpi/hunter.cmake
+++ b/cmake/projects/Boost/mpi/hunter.cmake
@@ -26,5 +26,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     mpi
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/nowide/hunter.cmake
+++ b/cmake/projects/Boost/nowide/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     nowide
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/program_options/hunter.cmake
+++ b/cmake/projects/Boost/program_options/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     program_options
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/python/hunter.cmake
+++ b/cmake/projects/Boost/python/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     python
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/random/hunter.cmake
+++ b/cmake/projects/Boost/random/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     random
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/regex/hunter.cmake
+++ b/cmake/projects/Boost/regex/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     regex
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -285,6 +285,14 @@ else()
   )
 endif()
 
+# pass defines set by `add_compile_definitions()` in cmake toolchain to boost-user.jam
+get_directory_property(dir_COMPILE_DEFINITIONS COMPILE_DEFINITIONS)
+foreach(compile_def ${dir_COMPILE_DEFINITIONS})
+  # Note: Flags should be quoted:
+  # - https://github.com/boostorg/build/issues/426#issuecomment-482564740
+  file( APPEND ${boost_user_jam} "  <compileflags>\"-D${compile_def}\"\n")
+endforeach()
+
 if(use_cmake_archiver)
   # We need custom '<archiver>' and '<ranlib>' for
   # Android LTO ('*-gcc-ar' instead of '*-ar')

--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -424,6 +424,12 @@ if(have_jobs)
   endif()
 endif()
 
+if("@WIN32@")
+  if(NOT "${BOOST_USE_WINAPI_VERSION}" STREQUAL "")
+    list(APPEND build_opts "define=BOOST_USE_WINAPI_VERSION=${BOOST_USE_WINAPI_VERSION}")
+  endif()
+endif()
+
 if(@HUNTER_STATUS_DEBUG@)
   set(verbose_output "-d+2 --debug-configuration")
 endif()

--- a/cmake/projects/Boost/serialization/hunter.cmake
+++ b/cmake/projects/Boost/serialization/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     serialization
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/signals/hunter.cmake
+++ b/cmake/projects/Boost/signals/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     signals
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/stacktrace/hunter.cmake
+++ b/cmake/projects/Boost/stacktrace/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     stacktrace
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/system/hunter.cmake
+++ b/cmake/projects/Boost/system/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     system
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/test/hunter.cmake
+++ b/cmake/projects/Boost/test/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     test
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/thread/hunter.cmake
+++ b/cmake/projects/Boost/thread/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     thread
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/timer/hunter.cmake
+++ b/cmake/projects/Boost/timer/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     timer
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/type_erasure/hunter.cmake
+++ b/cmake/projects/Boost/type_erasure/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     type_erasure
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/cmake/projects/Boost/wave/hunter.cmake
+++ b/cmake/projects/Boost/wave/hunter.cmake
@@ -18,5 +18,5 @@ hunter_download(
     Boost
     PACKAGE_COMPONENT
     wave
-    PACKAGE_INTERNAL_DEPS_ID "49"
+    PACKAGE_INTERNAL_DEPS_ID "50"
 )

--- a/docs/packages/pkg/Boost.rst
+++ b/docs/packages/pkg/Boost.rst
@@ -107,11 +107,18 @@ config file (``boost/config/user.hpp``):
   
   - `Boost-log-useBoostConfig <https://github.com/cpp-pm/hunter/blob/master/examples/Boost-log-useBoostConfig/CMakeLists.txt>`__
 
-- Option ``BOOST_BUILD_DYNAMIC_VSRUNTIME=OFF`` use on Windows to build the boost libraries with the static runtime.
+- Option ``BOOST_USE_WINAPI_VERSION=<API_VERSION>`` use on Windows in order to set the Windows API version used for building the boost libraries.
 
-  Should be used together with ``USE_CONFIG_FROM_BOOST=ON``.
-  Otherwise the generated library filenames won't be found by the provided ``FindBoost.cmake`` module.
+  Since Boost 1.78.0 Boost.Log exports additional symbols when building for Windows 8 or newer.
+  So it is recommended to set the CMake variable ``BOOST_USE_WINAPI_VERSION`` in the CMake-toolchain file (or the ``CMAKE_ARGS``) to the same value as the defines ``_WIN32_WINNT`` and ``WINVER``.
 
+  - `Boost.WinAPI documentation <https://www.boost.org/doc/libs/1_79_0/libs/winapi/doc/html/winapi/config.html>`__
+
+  The version passed must match the hexadecimal integer values used for ``_WIN32_WINNT`` and ``WINVER``.
+  The version numbers are described in
+  `Windows Headers documentation <https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers?redirectedfrom=MSDN#macros_for_conditional_declarations>`__.
+
+  ``API_VERSION`` is passed as a hexadecimal integer e.g. ``BOOST_USE_WINAPI_VERSION=0x0603`` sets the Windows API version to Windows 8.1.
 
 Python
 ------


### PR DESCRIPTION
Fix Boost.Log usage when the project is explicitly built for Windows 8
or newer. Boost.Log builds per default build for Windows 7, which breaks
the build because the boost-header will be used in a Windows 8 context,
but the Windows 8 specific functions are not compiled into the library.

The changelog for Boost 1.78 mentions `BOOST_USE_WINAPI_VERSION` for
`Atomic` and `Log` libraries https://www.boost.org/users/history/version_1_78_0.html

> ### Atomic:
> - On Windows, corrected discrepancy between `atomic-type::always_has_native_wait_notify` and the corresponding capability macros when targeting Windows 8 or later. The library will now directly use `WaitOnAddress` and related APIs from public headers and therefore require user to link with `synchronization.lib` if the user requires Windows 8 or later by defining `BOOST_USE_WINAPI_VERSION`, `_WIN32_WINNT` or similar macros. The library is linked automatically on compilers that support auto-linking (e.g. MSVC).

> ### Log:
> - On Windows, when building the library for Windows 8 or later, the library will use `nt62` tag in the version namespace to denote the target OS ABI. For example, the version namespace could be named as `v2_mt_nt62`. This name will be part of all symbols exported by the library. Use the `BOOST_USE_WINAPI_VERSION` macro consistenly when building Boost and your code to request the minimum target Windows version.

To fix this pass the `BOOST_USE_WINAPI_VERSION` when the CMake variable is
set (either by CMAKE_ARGS or in a toolchain file) to bjam using the
`define=` bjam commandline.

The `define=` usage is documented at
https://www.boost.org/doc/libs/1_79_0/libs/log/doc/html/log/installation/config.html

The `BOOST_USE_WINAPI_VERSION` define is documented for WinAPI and Log:
- https://www.boost.org/doc/libs/1_79_0/libs/winapi/doc/html/winapi/config.html
- https://www.boost.org/doc/libs/1_79_0/libs/log/doc/html/log/installation/config.html

Also push the internal schema version number to trigger a rebuild, as the
schema is changed.
