### PR TITLE
SuiteSparse: per default build with Metis support for ceres 2.2.0

### DIFF
--- a/cmake/projects/SuiteSparse/hunter.cmake
+++ b/cmake/projects/SuiteSparse/hunter.cmake
@@ -52,7 +52,8 @@ hunter_add_version(
 hunter_cmake_args(
     SuiteSparse
     CMAKE_ARGS
-    BUILD_METIS=NO
+    # 2022-06-22: ceres-solver starting with v2.2.0 expects Metis to be available if SuiteSparse is found
+    BUILD_METIS=YES
     HUNTER_INSTALL_LICENSE_FILES=LICENSE.md
 )
 


### PR DESCRIPTION
Starting with ceres-solver 2.2.0 if SuiteSparse is found it is expected to be built with Metis support.

In preparation for the next release change the default to build with Metis support

ceres-solver commit introducing SuiteSparse+Metis: https://github.com/ceres-solver/ceres-solver/commit/39ec5e8f99c595226ab3cd760d4945e61c31fc57
