### PR TITLE
Boost: update to v1.79.0

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -37,7 +37,7 @@ if(MINGW)
   # https://github.com/boostorg/build/issues/301
   hunter_default_version(Boost VERSION 1.64.0)
 else()
-  hunter_default_version(Boost VERSION 1.78.0)
+  hunter_default_version(Boost VERSION 1.79.0)
 endif()
 
 hunter_default_version(BoostCompute VERSION 0.5-p0)

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -234,6 +234,17 @@ hunter_add_version(
     7ccc47e82926be693810a687015ddc490b49296d
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.79.0"
+    URL
+    "https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2"
+    SHA1
+    31209dcff292bd6a64e5e08ceb3ce44a33615dc0
+)
+
 # up until 1.63 sourcefourge was used, base url https://downloads.sourceforge.net/project/boost/boost
 hunter_add_version(
     PACKAGE_NAME


### PR DESCRIPTION
Update Boost package to v1.79.0.

Release notes: https://www.boost.org/users/history/version_1_79_0.html

<!--- Use this part of template if you're updating existing package. Remove the rest. -->
<!--- BEGIN -->

* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**

