### PR TITLE
Add note about updating copyright notes to the manual

### DIFF
--- a/docs/creating-new/create/cmake.rst
+++ b/docs/creating-new/create/cmake.rst
@@ -275,7 +275,9 @@ Download release archive and calculate ``SHA1``:
 Add this information to ``cmake/projects/hunter_box_1/hunter.cmake`` file:
 
 .. code-block:: cmake
-  :emphasize-lines: 10, 12, 14, 16
+  :emphasize-lines: 1, 12, 14, 16, 18
+  # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
+  # All rights reserved.
 
   # !!! DO NOT PLACE HEADER GUARDS HERE !!!
 
@@ -402,7 +404,8 @@ Create example
   [hunter]> sed -i 's,foo,hunter_box_1,g' examples/hunter_box_1/*
 
 Tweak all files in ``examples/hunter_box_1`` directory to fit headers and
-names of imported targets.
+names of imported targets. Don't forget to update the copyright notices in 
+`examples/hunter_box_1/CMakeLists.txt` with your name.
 
 Add documentation
 =================

--- a/docs/creating-new/create/cmake.rst
+++ b/docs/creating-new/create/cmake.rst
@@ -277,7 +277,7 @@ Add this information to ``cmake/projects/hunter_box_1/hunter.cmake`` file:
 .. code-block:: cmake
   :emphasize-lines: 1, 13, 15, 17, 19
   
-  # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
+  # Copyright (c) 2025-20XX, <your-name-here>
   # All rights reserved.
 
   # !!! DO NOT PLACE HEADER GUARDS HERE !!!

--- a/docs/creating-new/create/cmake.rst
+++ b/docs/creating-new/create/cmake.rst
@@ -406,7 +406,7 @@ Create example
 
 Tweak all files in ``examples/hunter_box_1`` directory to fit headers and
 names of imported targets. Don't forget to update the copyright notices in 
-``examples/hunter_box_1/CMakeLists.txt`` with your name.
+``examples/hunter_box_1/CMakeLists.txt`` with the current year and your name.
 
 Add documentation
 =================

--- a/docs/creating-new/create/cmake.rst
+++ b/docs/creating-new/create/cmake.rst
@@ -275,7 +275,8 @@ Download release archive and calculate ``SHA1``:
 Add this information to ``cmake/projects/hunter_box_1/hunter.cmake`` file:
 
 .. code-block:: cmake
-  :emphasize-lines: 1, 12, 14, 16, 18
+  :emphasize-lines: 1, 13, 15, 17, 19
+  
   # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
   # All rights reserved.
 
@@ -405,7 +406,7 @@ Create example
 
 Tweak all files in ``examples/hunter_box_1`` directory to fit headers and
 names of imported targets. Don't forget to update the copyright notices in 
-`examples/hunter_box_1/CMakeLists.txt` with your name.
+``examples/hunter_box_1/CMakeLists.txt`` with your name.
 
 Add documentation
 =================


### PR DESCRIPTION
* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **Yes**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **Yes**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **Yes**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **Yes*

As @NeroBurner pointed out in https://github.com/cpp-pm/hunter/pull/600 one should update the copyright notices when a new package is created. This PR points this out to the user in the guide to create a new package.

