### PR TITLE
Boost: Add support for iOS simulator-only builds

### DIFF
--- a/cmake/modules/hunter_dump_cmake_flags.cmake
+++ b/cmake/modules/hunter_dump_cmake_flags.cmake
@@ -14,9 +14,10 @@ include(hunter_assert_not_empty_string)
 # * odb-boost
 # * ncursesw
 function(hunter_dump_cmake_flags)
-  cmake_parse_arguments(x "SKIP_INCLUDES;SKIP_PIC" "CPPFLAGS" "" "${ARGV}")
+  cmake_parse_arguments(x "SKIP_INCLUDES;SKIP_PIC;SKIP_DEPLOYMENT_TARGET" "CPPFLAGS" "" "${ARGV}")
   # -> x_SKIP_INCLUDES
   # -> x_SKIP_PIC
+  # -> x_SKIP_DEPLOYMENT_TARGET
   # -> x_CPPFLAGS
 
   string(COMPARE NOTEQUAL "${x_UNPARSED_ARGUMENTS}" "" has_unparsed)
@@ -24,16 +25,17 @@ function(hunter_dump_cmake_flags)
     hunter_internal_error("Unparsed arguments: ${x_UNPARSED_ARGUMENTS}")
   endif()
 
-
   if(IOS)
-    hunter_assert_not_empty_string("${IOS_SDK_VERSION}")
-    string(COMPARE EQUAL "${IOS_DEPLOYMENT_SDK_VERSION}" "" _no_deployment_sdk_version)
-    if(_no_deployment_sdk_version)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -miphoneos-version-min=${IOS_SDK_VERSION}")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -miphoneos-version-min=${IOS_SDK_VERSION}")
-    else()
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -miphoneos-version-min=${IOS_DEPLOYMENT_SDK_VERSION}")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -miphoneos-version-min=${IOS_DEPLOYMENT_SDK_VERSION}")
+    if(NOT x_SKIP_DEPLOYMENT_TARGET)
+      hunter_assert_not_empty_string("${IOS_SDK_VERSION}")
+      string(COMPARE EQUAL "${IOS_DEPLOYMENT_SDK_VERSION}" "" _no_deployment_sdk_version)
+      if(_no_deployment_sdk_version)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -miphoneos-version-min=${IOS_SDK_VERSION}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -miphoneos-version-min=${IOS_SDK_VERSION}")
+      else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -miphoneos-version-min=${IOS_DEPLOYMENT_SDK_VERSION}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -miphoneos-version-min=${IOS_DEPLOYMENT_SDK_VERSION}")
+      endif()
     endif()
 
     if(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE)
@@ -55,10 +57,12 @@ function(hunter_dump_cmake_flags)
       set(cppflags "-isysroot ${CMAKE_OSX_SYSROOT}")
     endif()
 
-    if(NOT "${CMAKE_OSX_DEPLOYMENT_TARGET}" STREQUAL "")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
-      set(cppflags "${cppflags} -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+    if(NOT x_SKIP_DEPLOYMENT_TARGET)
+      if(NOT "${CMAKE_OSX_DEPLOYMENT_TARGET}" STREQUAL "")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+        set(cppflags "${cppflags} -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+      endif()
     endif()
   endif()
 

--- a/cmake/modules/hunter_pick_scheme.cmake
+++ b/cmake/modules/hunter_pick_scheme.cmake
@@ -23,7 +23,12 @@ function(hunter_pick_scheme)
     hunter_internal_error("hunter_pick_scheme unparsed: ${x_UNPARSED_ARGUMENTS}")
   endif()
 
-  string(COMPARE EQUAL "${CMAKE_OSX_SYSROOT}" "iphoneos" is_iphoneos)
+  set(_apple_embedded "iphoneos" "iphonesimulator" "appletvos" "appletvsimulator" "watchos" "watchsimulator")
+  list(FIND _apple_embedded "${CMAKE_OSX_SYSROOT}" _found)
+  set(is_iphoneos FALSE)
+  if (${_found} GREATER -1)
+    set(is_iphoneos TRUE)
+  endif()
 
   # set HUNTER_DOWNLOAD_SCHEME
   if(is_iphoneos AND x_IPHONEOS)

--- a/cmake/projects/Boost/schemes/url_sha1_boost_ios_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_ios_library.cmake.in
@@ -149,11 +149,21 @@ hunter_boost_component_b2_args(
 
 list(APPEND build_opts ${b2_component_opts})
 
-hunter_dump_cmake_flags()
+# SKIP_DEPLOYMENT_TARGET as different targets (ios, iossim, etc) need different ones
+hunter_dump_cmake_flags(SKIP_DEPLOYMENT_TARGET)
 # -> CMAKE_CXX_FLAGS
 
-if(CMAKE_CXX_FLAGS)
-  list(APPEND build_opts "cxxflags=${CMAKE_CXX_FLAGS}")
+set(cmake_cxx_flags_iphoneos "${CMAKE_CXX_FLAGS}")
+set(cmake_cxx_flags_iphonesimulator "${CMAKE_CXX_FLAGS}")
+
+if(IOS_DEPLOYMENT_SDK_VERSION)
+  set(cmake_cxx_flags_iphoneos "${cmake_cxx_flags_iphoneos} -miphoneos-version-min=${IOS_DEPLOYMENT_SDK_VERSION}")
+  set(cmake_cxx_flags_iphonesimulator "${cmake_cxx_flags_iphonesimulator} -mios-simulator-version-min=${IOS_DEPLOYMENT_SDK_VERSION}")
+endif()
+
+if(CMAKE_CXX_FLAGS AND IOS_DEPLOYMENT_SDK_VERSION)
+  list(APPEND build_opts_iphoneos "cxxflags=${cmake_cxx_flags_iphoneos}")
+  list(APPEND build_opts_iphonesimulator "cxxflags=${cmake_cxx_flags_iphonesimulator}")
 endif()
 
 string(COMPARE NOTEQUAL "@HUNTER_JOBS_OPTION@" "" have_jobs)

--- a/cmake/projects/Boost/schemes/url_sha1_boost_ios_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_ios_library.cmake.in
@@ -255,10 +255,17 @@ else()
 endif()
 
 if(has_isim)
+  if (has_iphoneos)
+    # CMake variable replacement means we need a dummy command, empty string is ignored
+    set(skip_download "DOWNLOAD_COMMAND" "${CMAKE_COMMAND}" -E echo "SKIPPING DOWNLOAD STEP")
+  endif()
+
   ExternalProject_Add(
       "@HUNTER_EP_NAME@-ios_sim"
-      DOWNLOAD_COMMAND
-      ""
+      URL
+      @HUNTER_PACKAGE_URL@
+      URL_HASH
+      SHA1=@HUNTER_PACKAGE_SHA1@
       DOWNLOAD_DIR
       "@HUNTER_PACKAGE_DOWNLOAD_DIR@"
       TLS_VERIFY
@@ -268,6 +275,7 @@ if(has_isim)
       INSTALL_DIR
       "@HUNTER_PACKAGE_INSTALL_PREFIX@"
           # not used, just avoid creating Install/<name> empty directory
+      "${skip_download}"
       CONFIGURE_COMMAND
       ${bootstrap}
       BUILD_COMMAND
@@ -281,7 +289,7 @@ if(has_isim)
       -d0
       ${build_opts_iphonesimulator}
       install
-      "--prefix=@HUNTER_PACKAGE_INSTALL_PREFIX@"  
+      "--prefix=@HUNTER_PACKAGE_INSTALL_PREFIX@"
   )
 else()
   # Add dummy target


### PR DESCRIPTION
* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---

Fixes Boost libraries (i.e. not the header only bit which was already fine) on iOS simulator only. hunter_pick_scheme was not choosing iOS schemes for `iphonesimulator` `CMAKE_OSX_SYSROOT`s before. Also the download step was being skipped as it was assuming that ios and simulator were being built together.

See https://github.com/cpp-pm/hunter/issues/588