### PR TITLE
add boost 1.80.0

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -37,7 +37,7 @@ if(MINGW)
   # https://github.com/boostorg/build/issues/301
   hunter_default_version(Boost VERSION 1.64.0)
 else()
-  hunter_default_version(Boost VERSION 1.79.0)
+  hunter_default_version(Boost VERSION 1.80.0)
 endif()
 
 hunter_default_version(BoostCompute VERSION 0.5-p0)

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -245,6 +245,17 @@ hunter_add_version(
     31209dcff292bd6a64e5e08ceb3ce44a33615dc0
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.80.0"
+    URL
+    "https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.7z"
+    SHA1
+    5463e5380ccd1564e57747969c9dcc852b82b237
+)
+
 # up until 1.63 sourcefourge was used, base url https://downloads.sourceforge.net/project/boost/boost
 hunter_add_version(
     PACKAGE_NAME


### PR DESCRIPTION
* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **Yes**

I used the 7z instead of the tar.bz2 because it almost 20MB smaller and cmake supports it as well.