### PR TITLE
aws-sdk-cpp: Fix link pointing to wrong fork

### DIFF
--- a/cmake/projects/aws-sdk-cpp/hunter.cmake
+++ b/cmake/projects/aws-sdk-cpp/hunter.cmake
@@ -48,9 +48,9 @@ hunter_add_version(
     VERSION
     1.9.278-p1
     URL
-    "https://github.com/hjmallon/aws-sdk-cpp.git"
+    "https://github.com/cpp-pm/aws-sdk-cpp.git"
     SHA1
-    da65b7edac9467265ea6cd762fbf20f5397e054b
+    0492bf18882ee04c1448c8f9d9c810e1721e6483
 )
 
 hunter_cmake_args(


### PR DESCRIPTION
* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes|]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes]**
* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---

Sorry @NeroBurner I should have labelled the other MR as 'do not merge until the upstream MR is merged and I have updated the links'. 😄 
