### PR TITLE
OpenBLAS: starting with 0.3.21 build with LAPACK support per default

### DIFF
--- a/cmake/projects/OpenBLAS/hunter.cmake
+++ b/cmake/projects/OpenBLAS/hunter.cmake
@@ -96,11 +96,20 @@ if(HUNTER_OpenBLAS_VERSION VERSION_LESS 0.3.1)
       "lib/cmake/openblas/OpenBLASConfig.cmake"
   )
 else()
+  if(HUNTER_OpenBLAS_VERSION VERSION_LESS 0.3.21)
+    set(_openblas_BUILD_WITHOUT_LAPACK "ON")
+  else()
+    # starting with 0.3.21 LAPACK support as a fallback with an
+    # f2c-converted copy of LAPACK 3.9.0 was introduced
+    # https://github.com/xianyi/OpenBLAS/releases/tag/v0.3.21
+    set(_openblas_BUILD_WITHOUT_LAPACK "OFF")
+  endif()
   hunter_cmake_args(
     OpenBLAS
     CMAKE_ARGS
+    BUILD_TESTING=OFF
     NOFORTRAN=1
-    BUILD_WITHOUT_LAPACK=ON
+    BUILD_WITHOUT_LAPACK=${_openblas_BUILD_WITHOUT_LAPACK}
   )
   hunter_pick_scheme(DEFAULT url_sha1_cmake)
   set(_openblas_unrelocatable_text_files "")

--- a/docs/packages/pkg/OpenBLAS.rst
+++ b/docs/packages/pkg/OpenBLAS.rst
@@ -1,6 +1,8 @@
 .. spelling::
 
     OpenBLAS
+    Fortran
+    LAPACK
 
 .. index:: math ; OpenBLAS
 
@@ -23,3 +25,6 @@ OpenBLAS
     hunter_add_package(OpenBLAS)
     find_package(OpenBLAS CONFIG REQUIRED)
     target_link_libraries(... OpenBLAS::OpenBLAS)
+
+Starting with OpenBLAS v0.3.21 LAPACK support is enabled by default in Hunter.
+This is due to upstream adding a f2c-converted copy of LAPACK 3.9.0 as fallback if no Fortran compiler is available.


### PR DESCRIPTION
Starting with OpenBLAS 0.3.21 a f2c-converted copy of LAPACK 3.9.0 is available as fallback when "no fortran compiler" is specified. This means we get full BLAS/LAPACK support with just a normal C++ compiler.

From the release notes: https://github.com/xianyi/OpenBLAS/releases/tag/v0.3.21

> - when no Fortran compiler is available, OpenBLAS builds will now automatically
>   build LAPACK from an f2c-converted copy of LAPACK 3.9.0 unless the NO_LAPACK option
>   is specified (more recent releases make too heavy use of Fortran90+ features to be easily convertible to C)

Also disable the building of tests when building for Hunter to save time
<!--- Use this part of template if you're updating existing package. Remove the rest. -->
<!--- BEGIN -->

* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**
