### PR TITLE
pages: add id anchor per project for direct link

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,8 +17,8 @@
 {% assign projects = site.data.projects | sort %}
 {% for project in projects %}
 {% assign job_ids = "" %}
-<tr class="highlight">
-    <td><strong>{{ project[0] }}</strong></td>
+<tr class="highlight" id="{{ project[0] }}">
+    <td><a href="#{{ project[0] }}"><strong>{{ project[0] }}</strong></a></td>
     {% for os in oses %}
     <td>
         {% for job in project[1] %}


### PR DESCRIPTION
Generate for each project an anchor (table id) and add the link to each project name. This can be used to link to a status of a specific project.

for example I can link to the `Boost` project table as follows: https://neroburner.github.io/hunter/#Eigen

For presentation purposes I've let the gh-pages be created on my fork (see link above)
