### PR TITLE
ceres-solver: per default disable CUDA support

### DIFF
--- a/cmake/projects/ceres-solver/hunter.cmake
+++ b/cmake/projects/ceres-solver/hunter.cmake
@@ -105,6 +105,8 @@ hunter_cmake_args(ceres-solver CMAKE_ARGS
     LAPACK=OFF
     SUITESPARSE=OFF
     CXSPARSE=OFF # since 1.14.0-p0
+    # user must explicitly opt in to compile wit CUDA support, since v2.1.0-p0
+    CUDA=OFF
     # OpenBLAS flag, alternative to LAPACK since v2.1.0-p0
     WITH_OPENBLAS=OFF
     # don't build tests


### PR DESCRIPTION
The latest ceres-solver `v2.1.0-p1` version tries to build against CUDA, introducing an unwanted runtime dependency.

The user should explicitly choose to build against system CUDA libraries (or provided by hunter).

Fixes: https://github.com/cpp-pm/hunter/issues/657
