### PR TITLE
hunter_setup_msvc: tolower to fix arm64 vs ARM64 confusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,19 @@
 name: CI
 on:
   push:
-    paths: [ 'cmake/projects/**' ]
+    paths:
+      - 'cmake/projects/**'
+      - 'cmake/modules/**'
+      - 'cmake/schemes/**'
+      - 'cmake/templates/**'
+      - 'tests/**'
   pull_request:
-    paths: [ 'cmake/projects/**' ]
+    paths:
+      - 'cmake/projects/**'
+      - 'cmake/modules/**'
+      - 'cmake/schemes/**'
+      - 'cmake/templates/**'
+      - 'tests/**'
   workflow_dispatch:
     inputs:
       project:
@@ -82,15 +92,22 @@ jobs:
       run: echo "##[set-output name=branch;]${GITHUB_REF#refs/heads/}"
       id: extract_branch
 
+    - name: Build hunter_tests Unix
+      if: runner.os != 'Windows' && matrix.toolchain == 'hunter_tests'
+      env:
+        PROJECT_DIR: ${{ matrix.example }}
+      run: |
+        bash ${{ matrix.script }}
+
     - name: Build on Unix
-      if: runner.os != 'Windows'
+      if: runner.os != 'Windows' && matrix.toolchain != 'hunter_tests'
       env:
         BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
       run: |
         bash ${{ matrix.script }}
 
     - name: Build on Windows
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && matrix.toolchain != 'hunter_tests'
       env:
         BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
       run: |

--- a/.github/workflows/ci/build_hunter_tests.sh
+++ b/.github/workflows/ci/build_hunter_tests.sh
@@ -1,0 +1,12 @@
+# Set the correct Python PATH
+export PATH="${HUNTER_PYTHON_LOCATION}:${PATH}"
+
+# Tune locations
+export PATH="${PWD}/_ci/cmake/bin:${PATH}"
+
+# we want to exit on the first error, and we want the run commands to be shown
+set -ex
+
+# Run build
+cmake -S "${PROJECT_DIR}" -B build_hunter_test -DHUNTER_ENABLED=ON -DHUNTER_STATUS_DEBUG=ON
+cmake --build build_hunter_test

--- a/.github/workflows/ci/matrix_hunter_tests.json
+++ b/.github/workflows/ci/matrix_hunter_tests.json
@@ -1,0 +1,26 @@
+[
+// { "example": "tests/simple",                           "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+// { "example": "tests/issue/22",                         "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+// { "example": "tests/issue/24/unit",                    "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/issue/107",                         "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+// { "example": "tests/issue/109/unit",                   "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/autotools-merge-lipo",              "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_create_args_file",           "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_create_dependency_entry",    "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_create_deps_info",           "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+// download cache tests disabled because upstream file missing
+//{ "example": "tests/hunter_download_cache_meta_file",   "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+//{ "example": "tests/hunter_download_cache_raw_file",    "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_generate_qt_info",           "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_get_package_deps",           "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_get_package_deps_recurse",   "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_pack_directory",             "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_register_dependency",        "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_setup_msvc",                 "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_sleep_before_download",      "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_unpack_directory",           "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_init_not_found_counter",     "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+// disabled because of 'Unexpected empty string' and I don't want to debug that test
+//{ "example": "tests/hunter_check_toolchain_definition", "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" },
+{ "example": "tests/hunter_standard_flag",              "toolchain": "hunter_tests", "os": "ubuntu-22.04", "python": "3.8", "script": "build_hunter_tests.sh" }
+]

--- a/.github/workflows/set_matrix.py
+++ b/.github/workflows/set_matrix.py
@@ -23,6 +23,7 @@ except IOError:
   sys.exit('Can\'t read changed files from files.json')
 
 projects = set()
+run_hunter_tests : bool = False
 
 p = re.compile('cmake/projects/([^/]+)')
 for file in files:
@@ -30,8 +31,16 @@ for file in files:
     project = p.match(file).group(1)
     if os.path.isdir('cmake/projects/' + project):
       projects.add(project)
+  if file.startswith("cmake/modules/"):
+    run_hunter_tests = True
+  if file.startswith("cmake/schemes/"):
+    run_hunter_tests = True
+  if file.startswith("cmake/templates/"):
+    run_hunter_tests = True
+  if file.startswith("tests/"):
+    run_hunter_tests = True
 
-if projects:
+if projects or run_hunter_tests:
   dafault_dir = '.github/workflows/ci/'
 
   default_matrix = json_from_file_ignore_comments(dafault_dir + 'matrix.json')
@@ -53,6 +62,12 @@ if projects:
         leg['script'] = dafault_dir + leg['script']
 
     include += project_matrix
+
+  if run_hunter_tests:
+    hunter_tests_matrix = json_from_file_ignore_comments(dafault_dir + 'matrix_hunter_tests.json')
+    for leg in hunter_tests_matrix:
+      leg['script'] = dafault_dir + leg['script']
+    include += hunter_tests_matrix
 
   print(json.dumps({'include': include}))
 else:

--- a/tests/hunter_setup_msvc/CMakeLists.txt
+++ b/tests/hunter_setup_msvc/CMakeLists.txt
@@ -22,9 +22,11 @@ function(run_check version architecture host_toolset expected_arch expected_host
   message("    CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE: ${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE}")
 
   message("  Expected output:")
-  message("    HUNTER_MSVC_VERSION: ${HUNTER_MSVC_VERSION}")
-  message("    HUNTER_MSVC_YEAR: ${HUNTER_MSVC_YEAR}")
-  message("    HUNTER_MSVC_ARCH: ${HUNTER_MSVC_ARCH}")
+  message("    HUNTER_MSVC_VERSION: ${expected_version}")
+  message("    HUNTER_MSVC_YEAR: ${expected_year}")
+  message("    HUNTER_MSVC_ARCH: ${expected_arch}")
+  message("    HUNTER_MSVC_ARCH_HOST: ${expected_host}")
+  message("    HUNTER_MSVC_ARCH_target: ${expected_target}")
 
   set(MSVC TRUE)
 
@@ -34,28 +36,63 @@ function(run_check version architecture host_toolset expected_arch expected_host
   set(HUNTER_TESTING TRUE)
   hunter_setup_msvc()
 
+  message("  Actual output:")
+  message("    HUNTER_MSVC_VERSION: ${HUNTER_MSVC_VERSION}")
+  message("    HUNTER_MSVC_YEAR: ${HUNTER_MSVC_YEAR}")
+  message("    HUNTER_MSVC_ARCH: ${HUNTER_MSVC_ARCH}")
+  message("    HUNTER_MSVC_ARCH_HOST: ${HUNTER_MSVC_ARCH_HOST}")
+  message("    HUNTER_MSVC_ARCH_TARGET: ${HUNTER_MSVC_ARCH_TARGET}")
+
   string(COMPARE EQUAL "${HUNTER_MSVC_ARCH}" "${expected_arch}" is_equal)
-  if(is_equal)
-    message("OK")
-  else()
-    message(FATAL_ERROR "Unexpected: ${HUNTER_MSVC_ARCH}")
+  if(NOT is_equal)
+    message(FATAL_ERROR "Unexpected HUNTER_MSVC_ARCH: ${HUNTER_MSVC_ARCH} expected: ${expected_arch}")
+  endif()
+
+  string(COMPARE EQUAL "${HUNTER_MSVC_ARCH_HOST}" "${expected_host}" is_equal)
+  if(NOT is_equal)
+    message(FATAL_ERROR "Unexpected HUNTER_MSVC_ARCH_HOST: ${HUNTER_MSVC_ARCH_HOST} expected: ${expected_host}")
+  endif()
+
+  string(COMPARE EQUAL "${HUNTER_MSVC_ARCH_TARGET}" "${expected_target}" is_equal)
+  if(NOT is_equal)
+    message(FATAL_ERROR "Unexpected HUNTER_MSVC_ARCH_TARGET: ${HUNTER_MSVC_ARCH_TARGET} expected: ${expected_target}")
   endif()
 
   string(COMPARE EQUAL "${HUNTER_MSVC_VERSION}" "${expected_version}" is_equal)
-  if(is_equal)
-    message("OK")
-  else()
-    message(FATAL_ERROR "Unexpected: ${HUNTER_MSVC_VERSION}")
+  if(NOT is_equal)
+    message(FATAL_ERROR "Unexpected HUNTER_MSVC_VERSION: ${HUNTER_MSVC_VERSION} expected: ${expected_version}")
   endif()
 
   string(COMPARE EQUAL "${HUNTER_MSVC_YEAR}" "${expected_year}" is_equal)
-  if(is_equal)
-    message("OK")
-  else()
-    message(FATAL_ERROR "Unexpected: ${HUNTER_MSVC_YEAR}")
+  if(NOT is_equal)
+    message(FATAL_ERROR "Unexpected HUNTER_MSVC_YEAR: ${HUNTER_MSVC_YEAR} expected: ${expected_year}")
   endif()
 endfunction()
 
+# test matrix run on Window 10 amd64 host with MSVC Build Tools 17 2022
+# |-------------------|----------------------------|---------------|--------------------------|
+# | vcvarsall.bat     | vcvars initialized for msg | cmake -A      | MSVC_CXX_ARCHITECTURE_ID |
+# |-------------------|----------------------------|---------------|--------------------------|
+# | x86               | x86                        | WIN32         | X86                      |
+# |-------------------|----------------------------|---------------|--------------------------|
+# | amd64             | x64                        | x64           | x64                      |
+# | AMD64             | x64                        | x64           | x64                      |
+# | x64               | x64                        | x64           | x64                      |
+# | amd64             | x64                        | X64           | x64                      |
+# | amd64             | x64                        | amd64         | ERROR                    |
+# | amd64_amd64       | ERROR                      |               |                          |
+# |-------------------|----------------------------|---------------|--------------------------|
+# | amd64_arm64       | x64_arm64                  | ARM64         | ARM64                    |
+# | AMD64_ARM64       | x64_arm64                  | ARM64         | ARM64                    |
+# | amd64_arm64       | x64_arm64                  | arm64         | ARM64                    |
+# | arm64             | arm64                      | ARM64         | ARM64                    |
+# |-------------------|----------------------------|---------------|--------------------------|
+# | arm64ec           | ERROR                      |               |                          |
+# | arm64             | arm64                      | ARM64EC       | ARM64EC                  |
+# | arm64             | arm64                      | arm64ec       | ARM64EC                  |
+# |-------------------|----------------------------|---------------|--------------------------|
+
+# building for x86
 run_check("1400" "X86" "" "x86" "x86" "x86" "8" "2005")
 run_check("1500" "X86" "" "x86" "x86" "x86" "9" "2008")
 run_check("1600" "X86" "" "x86" "x86" "x86" "10" "2010")
@@ -65,6 +102,7 @@ run_check("1900" "X86" "" "x86" "x86" "x86" "14" "2015")
 run_check("1910" "X86" "" "x86" "x86" "x86" "15" "2017")
 run_check("1920" "X86" "" "x86" "x86" "x86" "16" "2019")
 
+# building for amd64/x64
 run_check("1400" "x64" "" "x86_amd64" "x86" "amd64" "8" "2005")
 run_check("1500" "x64" "" "x86_amd64" "x86" "amd64" "9" "2008")
 run_check("1600" "x64" "" "x86_amd64" "x86" "amd64" "10" "2010")
@@ -73,8 +111,11 @@ run_check("1800" "x64" "" "x86_amd64" "x86" "amd64" "12" "2013")
 run_check("1900" "x64" "" "x86_amd64" "x86" "amd64" "14" "2015")
 run_check("1910" "x64" "" "x86_amd64" "x86" "amd64" "15" "2017")
 run_check("1920" "x64" "" "x86_amd64" "x86" "amd64" "16" "2019")
+run_check("1930" "x64" "" "x86_amd64" "x86" "amd64" "17" "2022")
 run_check("1920" "x64" "x64" "amd64" "amd64" "amd64" "16" "2019")
+run_check("1930" "x64" "x64" "amd64" "amd64" "amd64" "17" "2022")
 
+# building for armv7
 run_check("1400" "ARMV7" "" "x86_arm" "x86" "arm" "8" "2005")
 run_check("1500" "ARMV7" "" "x86_arm" "x86" "arm" "9" "2008")
 run_check("1600" "ARMV7" "" "x86_arm" "x86" "arm" "10" "2010")
@@ -85,6 +126,14 @@ run_check("1910" "ARMV7" "" "x86_arm" "x86" "arm" "15" "2017")
 run_check("1920" "ARMV7" "" "x86_arm" "x86" "arm" "16" "2019")
 run_check("1920" "ARMV7" "x64" "amd64_arm" "amd64" "arm" "16" "2019")
 
+# building for ARM64
 run_check("1910" "ARM64" "" "x86_arm64" "x86" "arm64" "15" "2017")
 run_check("1920" "ARM64" "" "x86_arm64" "x86" "arm64" "16" "2019")
 run_check("1920" "ARM64" "x64" "amd64_arm64" "amd64" "arm64" "16" "2019")
+run_check("1930" "ARM64" "x64" "amd64_arm64" "amd64" "arm64" "17" "2022")
+run_check("1930" "ARM64" "arm64" "arm64" "arm64" "arm64" "17" "2022")
+
+# building for ARM64EC (Emulation Compatible), since Windows 11 SDK
+run_check("1930" "ARM64EC" "" "x86_arm64ec" "x86" "arm64ec" "17" "2022")
+run_check("1930" "ARM64EC" "x64" "amd64_arm64ec" "amd64" "arm64ec" "17" "2022")
+run_check("1930" "ARM64EC" "arm64" "arm64_arm64ec" "arm64" "arm64ec" "17" "2022")


### PR DESCRIPTION
`HUNTER_MSVC_ARCH` should match the capitalization of the `vcvarsall.bat <arch>` argument. The arch argument according to `vcvarsall.bat /help` can be one of the following:

```
[arch]: x86 | amd64 | x86_amd64 | x86_arm | x86_arm64 | amd64_x86 | amd64_arm | amd64_arm64
```

But to be more like `vcvarsall.at` and `cmake -A`, be case-insensitive with the input architectures.

And for less confusion, always output the `HUNTER_ARCH` variables in lower case.

In the process cleanup, fix and extend the corresponding unittest.

Fixes: https://github.com/cpp-pm/hunter/issues/679
