### PR TITLE
#685 Minimum cmake version required now 3.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ assignees: ''
 ```cmake
 # CMakeLists.txt
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 include("cmake/HunterGate.cmake")
 HunterGate(

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@
 
 * I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes|No]**
 * I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[Yes|No]**
-* My change will work with CMake 3.2 (minimum requirement for Hunter). **[Yes|No]**
+* My change will work with CMake 3.5 (minimum requirement for Hunter). **[Yes|No]**
 * I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes|No]**
 
 ---

--- a/cmake/modules/hunter_apply_gate_settings.cmake
+++ b/cmake/modules/hunter_apply_gate_settings.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(CMakeParseArguments) # cmake_parse_arguments
 

--- a/cmake/modules/hunter_boost_component_b2_args.cmake
+++ b/cmake/modules/hunter_boost_component_b2_args.cmake
@@ -2,7 +2,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # for iostreams dependency on ZLIB and BZIP2
 include(hunter_add_package)

--- a/cmake/modules/hunter_calculate_config_sha1.cmake
+++ b/cmake/modules/hunter_calculate_config_sha1.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(hunter_assert_not_empty_string)
 include(hunter_config)

--- a/cmake/modules/hunter_calculate_self.cmake
+++ b/cmake/modules/hunter_calculate_self.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(hunter_internal_error)
 include(hunter_assert_not_empty_string)

--- a/cmake/modules/hunter_lock_directory.cmake
+++ b/cmake/modules/hunter_lock_directory.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(hunter_fatal_error)
 include(hunter_status_debug)

--- a/cmake/modules/hunter_make_directory.cmake
+++ b/cmake/modules/hunter_make_directory.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(hunter_internal_error)
 include(hunter_lock_directory)

--- a/cmake/modules/hunter_set_config_location.cmake
+++ b/cmake/modules/hunter_set_config_location.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(hunter_internal_error)
 include(hunter_status_print)

--- a/cmake/modules/hunter_setup_msvc.cmake
+++ b/cmake/modules/hunter_setup_msvc.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2014-2016, Ruslan Baratov, Sumedh Ghaisas
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(hunter_fatal_error)
 include(hunter_internal_error)

--- a/cmake/projects/Avahi/schemes/url_sha1_avahi_autotools.cmake.in
+++ b/cmake/projects/Avahi/schemes/url_sha1_avahi_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")

--- a/cmake/projects/Boost/schemes/url_sha1_boost.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/Boost/schemes/url_sha1_boost_ios_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_ios_library.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
+++ b/cmake/projects/Boost/schemes/url_sha1_boost_library.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/NASM/schemes/url_sha1_nasm_windows.cmake.in
+++ b/cmake/projects/NASM/schemes/url_sha1_nasm_windows.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Zhuhao Wang
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/OpenBLAS/schemes/OpenBLAS.cmake.in
+++ b/cmake/projects/OpenBLAS/schemes/OpenBLAS.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2016 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/OpenSSL/ep-stages/configure.cmake.in
+++ b/cmake/projects/OpenSSL/ep-stages/configure.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 if(NOT "@NASM_ROOT@" STREQUAL "")
   set(ENV{PATH} "@NASM_ROOT@/bin;$ENV{PATH}")

--- a/cmake/projects/OpenSSL/ep-stages/configure_1_1_plus.cmake.in
+++ b/cmake/projects/OpenSSL/ep-stages/configure_1_1_plus.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 if(NOT "@NASM_ROOT@" STREQUAL "")
   set(ENV{PATH} "@NASM_ROOT@/bin;$ENV{PATH}")

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_ios.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_ios.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_macos.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_macos.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows_1_1_plus.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl_windows_1_1_plus.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/Qt/ep-stages/qt-build.cmake.in
+++ b/cmake/projects/Qt/ep-stages/qt-build.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 ### Input params check
 

--- a/cmake/projects/Qt/ep-stages/qt-configure.cmake.in
+++ b/cmake/projects/Qt/ep-stages/qt-configure.cmake.in
@@ -1,5 +1,5 @@
 ### Input params check
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 string(COMPARE EQUAL "@configure_command@" "" is_empty)
 if(is_empty)

--- a/cmake/projects/Qt/ep-stages/qt-install.cmake.in
+++ b/cmake/projects/Qt/ep-stages/qt-install.cmake.in
@@ -1,5 +1,5 @@
 ### Input params check
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 string(COMPARE EQUAL "@global_install_dir@" "" is_empty)
 if(is_empty)

--- a/cmake/projects/Qt/schemes/url_sha1_qt.cmake.in
+++ b/cmake/projects/Qt/schemes/url_sha1_qt.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015-2016 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/botan/schemes/url_sha1_botan.cmake.in
+++ b/cmake/projects/botan/schemes/url_sha1_botan.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(Hunter)
 

--- a/cmake/projects/botan/schemes/url_sha1_botan_ios.cmake.in
+++ b/cmake/projects/botan/schemes/url_sha1_botan_ios.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(Hunter)
 

--- a/cmake/projects/botan/schemes/url_sha1_botan_macos.cmake.in
+++ b/cmake/projects/botan/schemes/url_sha1_botan_macos.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(Hunter)
 

--- a/cmake/projects/botan/schemes/url_sha1_botan_win.cmake.in
+++ b/cmake/projects/botan/schemes/url_sha1_botan_win.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(Hunter)
 

--- a/cmake/projects/flex/schemes/url_sha1_flex_autotools.cmake.in
+++ b/cmake/projects/flex/schemes/url_sha1_flex_autotools.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")

--- a/cmake/projects/libsodium/schemes/url_sha1_libsodium_autogen_autotools.cmake.in
+++ b/cmake/projects/libsodium/schemes/url_sha1_libsodium_autogen_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")

--- a/cmake/projects/libsodium/schemes/url_sha1_libsodium_msbuild.cmake.in
+++ b/cmake/projects/libsodium/schemes/url_sha1_libsodium_msbuild.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 

--- a/cmake/projects/libxml2/schemes/url_sha1_libxml2_msvc.cmake.in
+++ b/cmake/projects/libxml2/schemes/url_sha1_libxml2_msvc.cmake.in
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, Sacha Refshauge
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/odb-boost/schemes/url_sha1_odb-boost_autotools.cmake.in
+++ b/cmake/projects/odb-boost/schemes/url_sha1_odb-boost_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2016 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/projects/odb-mysql/schemes/url_sha1_odb-mysql_autotools.cmake.in
+++ b/cmake/projects/odb-mysql/schemes/url_sha1_odb-mysql_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2016 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/projects/odb-pgsql/schemes/url_sha1_odb-pgsql_autotools.cmake.in
+++ b/cmake/projects/odb-pgsql/schemes/url_sha1_odb-pgsql_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2016 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/projects/odb-sqlite/schemes/url_sha1_odb-sqlite_autotools.cmake.in
+++ b/cmake/projects/odb-sqlite/schemes/url_sha1_odb-sqlite_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/projects/tcl/schemes/url_sha1_tcl_autotools.cmake.in
+++ b/cmake/projects/tcl/schemes/url_sha1_tcl_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/projects/x264/schemes/url_sha1_x264.cmake.in
+++ b/cmake/projects/x264/schemes/url_sha1_x264.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2017 Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/projects/xcb/schemes/xcb.cmake.in
+++ b/cmake/projects/xcb/schemes/xcb.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2016 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/schemes/git_tag_cmake.cmake.in
+++ b/cmake/schemes/git_tag_cmake.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/schemes/url_sha1_autogen_autotools.cmake.in
+++ b/cmake/schemes/url_sha1_autogen_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 list(APPEND CMAKE_MODULE_PATH "@HUNTER_SELF@/cmake/modules")

--- a/cmake/schemes/url_sha1_autotools.cmake.in
+++ b/cmake/schemes/url_sha1_autotools.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include("@HUNTER_SELF@/cmake/Hunter")

--- a/cmake/schemes/url_sha1_cmake.cmake.in
+++ b/cmake/schemes/url_sha1_cmake.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/schemes/url_sha1_download.cmake.in
+++ b/cmake/schemes/url_sha1_download.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/schemes/url_sha1_ios_sim.cmake.in
+++ b/cmake/schemes/url_sha1_ios_sim.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/schemes/url_sha1_make_only.cmake.in
+++ b/cmake/schemes/url_sha1_make_only.cmake.in
@@ -1,5 +1,5 @@
 # This is configuration file, variable @SOME_VARIABLE_NAME@ will be substituted during configure_file command
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # If such variables like `CMAKE_CXX_FLAGS` or `CMAKE_CXX_COMPILER` not used by scheme
 # setting `LANGUAGES` to `NONE` will speed-up build a little bit. If you have any problems/glitches

--- a/cmake/schemes/url_sha1_unpack.cmake.in
+++ b/cmake/schemes/url_sha1_unpack.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(ExternalProject) # ExternalProject_Add
 

--- a/cmake/schemes/url_sha1_unpack_bin_install.cmake.in
+++ b/cmake/schemes/url_sha1_unpack_bin_install.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Zhuhao Wang
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(Hunter)
 
 include(ExternalProject) # ExternalProject_Add

--- a/cmake/schemes/url_sha1_unpack_install.cmake.in
+++ b/cmake/schemes/url_sha1_unpack_install.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2015 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Unpack the archive and copy contents to HUNTER_PACKAGE_INSTALL_PREFIX
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -59,7 +59,7 @@ and working correctly. Before reporting bugs please check:
 
     # CMakeLists.txt
 
-    cmake_minimum_required(VERSION 3.2)
+    cmake_minimum_required(VERSION 3.5)
     project(foo)
 
     add_executable(foo foo.cpp)

--- a/docs/creating-new/create/custom.rst
+++ b/docs/creating-new/create/custom.rst
@@ -29,7 +29,7 @@ Test it using ``ExternalProject_Add``
 .. code-block:: bash
 
     > cat CMakeLists.txt
-    cmake_minimum_required(VERSION 3.2)
+    cmake_minimum_required(VERSION 3.5)
 
     include(ExternalProject) # ExternalProject_Add
 
@@ -65,7 +65,7 @@ First, custom build scheme need to be added to ``cmake/schemes`` directory:
     > cd ${HUNTER_ROOT}
     > cat cmake/schemes/url_sha1_ios_sim.cmake.in
     # This is configuration file, variable @SOME_VARIABLE_NAME@ will be substituted during configure_file command
-    cmake_minimum_required(VERSION 3.2)
+    cmake_minimum_required(VERSION 3.5)
 
     # If such variables like `CMAKE_CXX_FLAGS` or `CMAKE_CXX_COMPILER` not used by scheme
     # setting `LANGUAGES` to `NONE` will speed-up build a little bit. If you have any problems/glitches
@@ -153,7 +153,7 @@ Now package ready to be used:
 .. code-block:: bash
 
     > cat CMakeLists.txt
-    cmake_minimum_required(VERSION 3.2)
+    cmake_minimum_required(VERSION 3.5)
 
     include("cmake/HunterGate.cmake")
 

--- a/docs/faq/how-to-fix-download-error.rst
+++ b/docs/faq/how-to-fix-download-error.rst
@@ -31,7 +31,7 @@ You can check that everything is fine by invoking this script:
 
   # script.cmake
 
-  cmake_minimum_required(VERSION 3.2)
+  cmake_minimum_required(VERSION 3.5)
 
   file(
       DOWNLOAD

--- a/docs/faq/why-hunter-is-slow.rst
+++ b/docs/faq/why-hunter-is-slow.rst
@@ -73,7 +73,7 @@ it may take much longer then with Makefile generator:
 
   # CMakeLists.txt
 
-  cmake_minimum_required(VERSION 3.2)
+  cmake_minimum_required(VERSION 3.5)
   project(foo)
 
 .. code-block:: none
@@ -115,7 +115,7 @@ option:
 
   # CMakeLists.txt
 
-  cmake_minimum_required(VERSION 3.2)
+  cmake_minimum_required(VERSION 3.5)
 
   option(
       HUNTER_NO_TOOLCHAIN_ID_RECALCULATION
@@ -169,7 +169,7 @@ As an example here are actions that can lead to incorrect cache state:
 
   # CMakeLists.txt
 
-  cmake_minimum_required(VERSION 3.2)
+  cmake_minimum_required(VERSION 3.5)
 
   option(
       HUNTER_NO_TOOLCHAIN_ID_RECALCULATION
@@ -227,7 +227,7 @@ And add "GTest" to CMakeLists.txt:
 
   # CMakeLists.txt
 
-  cmake_minimum_required(VERSION 3.2)
+  cmake_minimum_required(VERSION 3.5)
 
   option(
       HUNTER_NO_TOOLCHAIN_ID_RECALCULATION
@@ -287,7 +287,7 @@ Xcode generator only:
 .. code-block:: cmake
   :emphasize-lines: 3-9
 
-  cmake_minimum_required(VERSION 3.2)
+  cmake_minimum_required(VERSION 3.5)
 
   if(CMAKE_GENERATOR STREQUAL "Xcode")
     option(

--- a/docs/old-wiki/usr.adding.new.package.custom.scheme.md
+++ b/docs/old-wiki/usr.adding.new.package.custom.scheme.md
@@ -16,7 +16,7 @@ build/Release/ios-sim
 ### 02. Test it using ExternalProject_Add
 ```bash
 > cat CMakeLists.txt
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include(ExternalProject) # ExternalProject_Add
 
@@ -49,7 +49,7 @@ First, custom build scheme need to be added to `cmake/schemes` directory
 > cd ${HUNTER_ROOT}
 > cat cmake/schemes/url_sha1_ios_sim.cmake.in
 # This is configuration file, variable @SOME_VARIABLE_NAME@ will be substituted during configure_file command
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # If such variables like `CMAKE_CXX_FLAGS` or `CMAKE_CXX_COMPILER` not used by scheme
 # setting `LANGUAGES` to `NONE` will speed-up build a little bit. If you have any problems/glitches

--- a/docs/quick-start/boost-components.rst
+++ b/docs/quick-start/boost-components.rst
@@ -17,7 +17,7 @@ Set minimum CMake version:
 
 .. code-block:: cmake
 
-  cmake_minimum_required(VERSION 3.2)
+  cmake_minimum_required(VERSION 3.5)
 
 Copy `HunterGate`_ module to your project and include it:
 
@@ -68,7 +68,7 @@ Summarize:
 .. code-block:: cmake
   :emphasize-lines: 5-6, 11
 
-  cmake_minimum_required(VERSION 3.2)
+  cmake_minimum_required(VERSION 3.5)
 
   include("cmake/HunterGate.cmake")
   HunterGate(

--- a/docs/quick-start/cmake.rst
+++ b/docs/quick-start/cmake.rst
@@ -6,6 +6,8 @@ Notes about version of CMake
 
 * `3.5.0`_ **Minimum required**
 
+  * Since: `PR #689 <https://github.com/cpp-pm/hunter/pull/689>`__
+
   * New variable `CMAKE_IOS_INSTALL_COMBINED <https://cmake.org/cmake/help/v3.5/variable/CMAKE_IOS_INSTALL_COMBINED.html>`__
   * `iOS toolchains <http://polly.readthedocs.io/en/latest/toolchains/ios.html>`__
 

--- a/docs/quick-start/cmake.rst
+++ b/docs/quick-start/cmake.rst
@@ -4,16 +4,7 @@
 Notes about version of CMake
 ----------------------------
 
-* `3.2.0`_ **Minimum required**
-
-  * New ``continue`` command
-  * New synchronization command ``file(LOCK ...)``
-
-* `3.4.1`_
-
-  * **Buggy**, see `issue #405 <https://github.com/ruslo/hunter/issues/405>`__
-
-* `3.5.0`_ **Minimum for iOS projects**
+* `3.5.0`_ **Minimum required**
 
   * New variable `CMAKE_IOS_INSTALL_COMBINED <https://cmake.org/cmake/help/v3.5/variable/CMAKE_IOS_INSTALL_COMBINED.html>`__
   * `iOS toolchains <http://polly.readthedocs.io/en/latest/toolchains/ios.html>`__
@@ -54,8 +45,6 @@ Notes about version of CMake
   Latest Hunter release with support of old Android toolchains
   (before CMake 3.7.1) is v0.16.36
 
-.. _3.2.0: https://www.cmake.org/cmake/help/v3.2/release/3.2.html#commands
-.. _3.4.1: https://www.cmake.org/cmake/help/v3.4/release/3.4.html
 .. _3.5.0: https://www.cmake.org/cmake/help/v3.5/release/3.5.html#platforms
 .. _3.7.0: https://cmake.org/cmake/help/latest/release/3.7.html#commands
 .. _3.7.1: https://cmake.org/cmake/help/latest/release/3.7.html#platforms

--- a/docs/reference/errors/error.hunteraddpackage.after.project.rst
+++ b/docs/reference/errors/error.hunteraddpackage.after.project.rst
@@ -26,7 +26,7 @@ What to do
   .. code-block:: cmake
 
      # Check CMake version before any commands
-     cmake_minimum_required(VERSION 3.2)
+     cmake_minimum_required(VERSION 3.5)
      
      # Load HunterGate module
      include("cmake/HunterGate.cmake")

--- a/docs/reference/errors/error.huntergate.before.project.rst
+++ b/docs/reference/errors/error.huntergate.before.project.rst
@@ -26,7 +26,7 @@ What to do
   .. code-block:: cmake
 
      # Check CMake version before any commands
-     cmake_minimum_required(VERSION 3.2)
+     cmake_minimum_required(VERSION 3.5)
      
      # Load HunterGate module
      include("cmake/HunterGate.cmake")
@@ -48,7 +48,7 @@ What to do
   .. code-block:: cmake
 
      # CMakeLists.txt
-     cmake_minimum_required(VERSION 3.2)
+     cmake_minimum_required(VERSION 3.5)
      include("cmake/HunterGate.cmake")
      HunterGate(URL ... SHA1 ...)
      add_subdirectory(subdir1)
@@ -63,7 +63,7 @@ What to do
   .. code-block:: cmake
 
      # CMakeLists.txt
-     cmake_minimum_required(VERSION 3.2)
+     cmake_minimum_required(VERSION 3.5)
      include("cmake/HunterGate.cmake")
      HunterGate(URL ... SHA1 ...)
      project(Foo) # <--------------- before add_subdirectory

--- a/docs/user-guides/hunter-user/artifactory-cache-server.rst
+++ b/docs/user-guides/hunter-user/artifactory-cache-server.rst
@@ -118,7 +118,7 @@ variable before ``HunterGate`` to configure ``Hunter`` to use ``Artifactory`` se
 .. code-block:: cmake
   :emphasize-lines: 4-5
 
-  cmake_minimum_required(VERSION 3.2)
+  cmake_minimum_required(VERSION 3.5)
 
   set(
       HUNTER_CACHE_SERVERS

--- a/docs/user-guides/hunter-user/git-submodule.rst
+++ b/docs/user-guides/hunter-user/git-submodule.rst
@@ -29,7 +29,7 @@ and set the ``GIT_SUBMODULE`` flag:
 
   # CMakeLists.txt
 
-  cmake_minimum_required(VERSION 3.2)
+  cmake_minimum_required(VERSION 3.5)
 
   include("cmake/HunterGate.cmake")
   HunterGate(
@@ -192,7 +192,7 @@ First let's remove ``LOCAL`` config and build standard TIFF with standard ZLIB:
   :emphasize-lines: 5-8
 
   # CMakeLists.txt
-  cmake_minimum_required(VERSION 3.2)
+  cmake_minimum_required(VERSION 3.5)
 
   include("cmake/HunterGate.cmake")
   HunterGate(
@@ -226,7 +226,7 @@ Now let's add ``LOCAL`` back and run build again:
 
   # CMakeLists.txt
 
-  cmake_minimum_required(VERSION 3.2)
+  cmake_minimum_required(VERSION 3.5)
 
   include("cmake/HunterGate.cmake")
   HunterGate(

--- a/examples/ARM_NEON_2_x86_SSE/CMakeLists.txt
+++ b/examples/ARM_NEON_2_x86_SSE/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/AllTheFlopsThreads/CMakeLists.txt
+++ b/examples/AllTheFlopsThreads/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Android-ARM-EABI-v7a-System-Image/CMakeLists.txt
+++ b/examples/Android-ARM-EABI-v7a-System-Image/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Android-ARM64-v8a-System-Image/CMakeLists.txt
+++ b/examples/Android-ARM64-v8a-System-Image/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Android-Build-Tools/CMakeLists.txt
+++ b/examples/Android-Build-Tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Android-MIPS-System-Image/CMakeLists.txt
+++ b/examples/Android-MIPS-System-Image/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Android-SDK-Platform-tools/CMakeLists.txt
+++ b/examples/Android-SDK-Platform-tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Android-SDK-Platform/CMakeLists.txt
+++ b/examples/Android-SDK-Platform/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Android-SDK-Tools/CMakeLists.txt
+++ b/examples/Android-SDK-Tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Android-SDK/CMakeLists.txt
+++ b/examples/Android-SDK/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/AngelScript/CMakeLists.txt
+++ b/examples/AngelScript/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ArrayFire/CMakeLists.txt
+++ b/examples/ArrayFire/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Assimp-linux/CMakeLists.txt
+++ b/examples/Assimp-linux/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Assimp/CMakeLists.txt
+++ b/examples/Assimp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Async++/CMakeLists.txt
+++ b/examples/Async++/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/BZip2/CMakeLists.txt
+++ b/examples/BZip2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Beast/CMakeLists.txt
+++ b/examples/Beast/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Sacha Refshauge
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Boost-chrono-1-64/CMakeLists.txt
+++ b/examples/Boost-chrono-1-64/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)

--- a/examples/Boost-chrono-useBoostConfig/CMakeLists.txt
+++ b/examples/Boost-chrono-useBoostConfig/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)

--- a/examples/Boost-chrono/CMakeLists.txt
+++ b/examples/Boost-chrono/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-compute/CMakeLists.txt
+++ b/examples/Boost-compute/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Boost-container/CMakeLists.txt
+++ b/examples/Boost-container/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-contract/CMakeLists.txt
+++ b/examples/Boost-contract/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-custom-args/CMakeLists.txt
+++ b/examples/Boost-custom-args/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 
 # Emulate HunterGate:

--- a/examples/Boost-fiber/CMakeLists.txt
+++ b/examples/Boost-fiber/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-filesystem-1-64/CMakeLists.txt
+++ b/examples/Boost-filesystem-1-64/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)

--- a/examples/Boost-filesystem-shared/CMakeLists.txt
+++ b/examples/Boost-filesystem-shared/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Boost-filesystem-useBoostConfig/CMakeLists.txt
+++ b/examples/Boost-filesystem-useBoostConfig/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)

--- a/examples/Boost-filesystem/CMakeLists.txt
+++ b/examples/Boost-filesystem/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-iostreams-1-64/CMakeLists.txt
+++ b/examples/Boost-iostreams-1-64/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 

--- a/examples/Boost-iostreams-useBoostConfig/CMakeLists.txt
+++ b/examples/Boost-iostreams-useBoostConfig/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)

--- a/examples/Boost-iostreams/CMakeLists.txt
+++ b/examples/Boost-iostreams/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Aaditya Kalsi
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-json/CMakeLists.txt
+++ b/examples/Boost-json/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-log-shared/CMakeLists.txt
+++ b/examples/Boost-log-shared/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-log-useBoostConfig/CMakeLists.txt
+++ b/examples/Boost-log-useBoostConfig/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)

--- a/examples/Boost-log/CMakeLists.txt
+++ b/examples/Boost-log/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-math/CMakeLists.txt
+++ b/examples/Boost-math/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-process/CMakeLists.txt
+++ b/examples/Boost-process/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Boost-program-options/CMakeLists.txt
+++ b/examples/Boost-program-options/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-python/CMakeLists.txt
+++ b/examples/Boost-python/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Modified work: Copyright (c) 2018, Gregory Kramida
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 option(HUNTER_BUILD_SHARED_LIBS "..." ON)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")

--- a/examples/Boost-random/CMakeLists.txt
+++ b/examples/Boost-random/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Pawel Bylica
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-serialization/CMakeLists.txt
+++ b/examples/Boost-serialization/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-stacktrace/CMakeLists.txt
+++ b/examples/Boost-stacktrace/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-system-1-66/CMakeLists.txt
+++ b/examples/Boost-system-1-66/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)

--- a/examples/Boost-system/CMakeLists.txt
+++ b/examples/Boost-system/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-test/CMakeLists.txt
+++ b/examples/Boost-test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-thread-1-64/CMakeLists.txt
+++ b/examples/Boost-thread-1-64/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)

--- a/examples/Boost-thread/CMakeLists.txt
+++ b/examples/Boost-thread/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-url/CMakeLists.txt
+++ b/examples/Boost-url/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost-useBoostConfig/CMakeLists.txt
+++ b/examples/Boost-useBoostConfig/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)

--- a/examples/Boost-uuid/CMakeLists.txt
+++ b/examples/Boost-uuid/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/Boost/CMakeLists.txt
+++ b/examples/Boost/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(Boost_DEBUG ON CACHE BOOLEAN "")
 

--- a/examples/BoringSSL/CMakeLists.txt
+++ b/examples/BoringSSL/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Box2D/CMakeLists.txt
+++ b/examples/Box2D/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/CLAPACK/CMakeLists.txt
+++ b/examples/CLAPACK/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/CLI11/CMakeLists.txt
+++ b/examples/CLI11/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/CURL-BoringSSL/CMakeLists.txt
+++ b/examples/CURL-BoringSSL/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 

--- a/examples/CURL-with-ares/CMakeLists.txt
+++ b/examples/CURL-with-ares/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 

--- a/examples/CURL/CMakeLists.txt
+++ b/examples/CURL/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/CapnProto/CMakeLists.txt
+++ b/examples/CapnProto/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Comet/CMakeLists.txt
+++ b/examples/Comet/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/CppNetlibUri/CMakeLists.txt
+++ b/examples/CppNetlibUri/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/CreateLaunchers/CMakeLists.txt
+++ b/examples/CreateLaunchers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/EGL-Registry/CMakeLists.txt
+++ b/examples/EGL-Registry/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Eigen-Boost/CMakeLists.txt
+++ b/examples/Eigen-Boost/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(HUNTER_USE_CACHE_SERVERS NO)
 

--- a/examples/Eigen/CMakeLists.txt
+++ b/examples/Eigen/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Expat/CMakeLists.txt
+++ b/examples/Expat/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2015, 2016, Alexander Lamaison
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/FLAC/CMakeLists.txt
+++ b/examples/FLAC/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/FP16/CMakeLists.txt
+++ b/examples/FP16/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Fruit/CMakeLists.txt
+++ b/examples/Fruit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/FunctionalPlus/CMakeLists.txt
+++ b/examples/FunctionalPlus/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2018, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/GPUImage/CMakeLists.txt
+++ b/examples/GPUImage/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2018, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/GSL/CMakeLists.txt
+++ b/examples/GSL/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/GTest/CMakeLists.txt
+++ b/examples/GTest/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/HalideIR/CMakeLists.txt
+++ b/examples/HalideIR/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/HastyNoise/CMakeLists.txt
+++ b/examples/HastyNoise/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ICU/CMakeLists.txt
+++ b/examples/ICU/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/IF97/CMakeLists.txt
+++ b/examples/IF97/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/IlmBase/CMakeLists.txt
+++ b/examples/IlmBase/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Imath/CMakeLists.txt
+++ b/examples/Imath/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Immer/CMakeLists.txt
+++ b/examples/Immer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Jpeg/CMakeLists.txt
+++ b/examples/Jpeg/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/KTX-Software/CMakeLists.txt
+++ b/examples/KTX-Software/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/KhronosDataFormat/CMakeLists.txt
+++ b/examples/KhronosDataFormat/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/LAPACK-CBLAS/CMakeLists.txt
+++ b/examples/LAPACK-CBLAS/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 
 set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")

--- a/examples/LAPACK-dynamic/CMakeLists.txt
+++ b/examples/LAPACK-dynamic/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
 

--- a/examples/LAPACK/CMakeLists.txt
+++ b/examples/LAPACK/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/LLVM/CMakeLists.txt
+++ b/examples/LLVM/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Lager/CMakeLists.txt
+++ b/examples/Lager/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c)
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/cpp-pm/gate

--- a/examples/Leathers/CMakeLists.txt
+++ b/examples/Leathers/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Leptonica/CMakeLists.txt
+++ b/examples/Leptonica/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/LibCDS/CMakeLists.txt
+++ b/examples/LibCDS/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/Libevent/CMakeLists.txt
+++ b/examples/Libevent/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/Libssh2/CMakeLists.txt
+++ b/examples/Libssh2/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2014, Alexander Lamaison
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/LodePNG/CMakeLists.txt
+++ b/examples/LodePNG/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Lua/CMakeLists.txt
+++ b/examples/Lua/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/MathFu/CMakeLists.txt
+++ b/examples/MathFu/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Microsoft.GSL/CMakeLists.txt
+++ b/examples/Microsoft.GSL/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/MySQL-client/CMakeLists.txt
+++ b/examples/MySQL-client/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2016, Alexandre Pretyman
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/NASM/CMakeLists.txt
+++ b/examples/NASM/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017 Zhuhao Wang
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/NLopt/CMakeLists.txt
+++ b/examples/NLopt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ONNX/CMakeLists.txt
+++ b/examples/ONNX/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/OpenAL/CMakeLists.txt
+++ b/examples/OpenAL/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/OpenBLAS/CMakeLists.txt
+++ b/examples/OpenBLAS/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/OpenCL-Headers/CMakeLists.txt
+++ b/examples/OpenCL-Headers/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/OpenCL-cpp/CMakeLists.txt
+++ b/examples/OpenCL-cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/OpenCL/CMakeLists.txt
+++ b/examples/OpenCL/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/OpenCV-Extra/CMakeLists.txt
+++ b/examples/OpenCV-Extra/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/OpenCV-Qt/CMakeLists.txt
+++ b/examples/OpenCV-Qt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/OpenCV-ffmpeg/CMakeLists.txt
+++ b/examples/OpenCV-ffmpeg/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 

--- a/examples/OpenCV/CMakeLists.txt
+++ b/examples/OpenCV/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/OpenEXR/CMakeLists.txt
+++ b/examples/OpenEXR/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/OpenGL-Registry/CMakeLists.txt
+++ b/examples/OpenGL-Registry/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/OpenNMTTokenizer/CMakeLists.txt
+++ b/examples/OpenNMTTokenizer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/OpenSSL-1.0.2/CMakeLists.txt
+++ b/examples/OpenSSL-1.0.2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 

--- a/examples/OpenSSL-asm/CMakeLists.txt
+++ b/examples/OpenSSL-asm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 

--- a/examples/OpenSSL/CMakeLists.txt
+++ b/examples/OpenSSL/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/OpenSceneGraph/CMakeLists.txt
+++ b/examples/OpenSceneGraph/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Opus/CMakeLists.txt
+++ b/examples/Opus/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/PNG/CMakeLists.txt
+++ b/examples/PNG/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2015, Alexander Lamaison
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/PROJ4/CMakeLists.txt
+++ b/examples/PROJ4/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/PhysUnits/CMakeLists.txt
+++ b/examples/PhysUnits/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/PocoCpp/CMakeLists.txt
+++ b/examples/PocoCpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/PostgreSQL/CMakeLists.txt
+++ b/examples/PostgreSQL/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2016, Alexandre Pretyman
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Protobuf-legacy/CMakeLists.txt
+++ b/examples/Protobuf-legacy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Protobuf-legacy/cmake/host/CMakeLists.txt
+++ b/examples/Protobuf-legacy/cmake/host/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake project to install protobuf::protoc from hunter Protobuf package
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Protobuf-optimized/CMakeLists.txt
+++ b/examples/Protobuf-optimized/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Protobuf-optimized/cmake/host/CMakeLists.txt
+++ b/examples/Protobuf-optimized/cmake/host/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake project to install protobuf::protoc from hunter Protobuf package
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Protobuf/CMakeLists.txt
+++ b/examples/Protobuf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Protobuf/cmake/host/CMakeLists.txt
+++ b/examples/Protobuf/cmake/host/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake project to install protobuf::protoc from hunter Protobuf package
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/QtAndroidCMake/CMakeLists.txt
+++ b/examples/QtAndroidCMake/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/QtCMakeExtra/CMakeLists.txt
+++ b/examples/QtCMakeExtra/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/QtPropertyEditor/CMakeLists.txt
+++ b/examples/QtPropertyEditor/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Qwt/CMakeLists.txt
+++ b/examples/Qwt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/RapidJSON/CMakeLists.txt
+++ b/examples/RapidJSON/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/RapidXML/CMakeLists.txt
+++ b/examples/RapidXML/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/RedisClient/CMakeLists.txt
+++ b/examples/RedisClient/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/SDL_ttf/CMakeLists.txt
+++ b/examples/SDL_ttf/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/SFML/CMakeLists.txt
+++ b/examples/SFML/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/SPIRV-Headers/CMakeLists.txt
+++ b/examples/SPIRV-Headers/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/SPIRV-Tools/CMakeLists.txt
+++ b/examples/SPIRV-Tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/SimpleSignal/CMakeLists.txt
+++ b/examples/SimpleSignal/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Snappy/CMakeLists.txt
+++ b/examples/Snappy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Sources-for-Android-SDK/CMakeLists.txt
+++ b/examples/Sources-for-Android-SDK/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Sqlpp11/CMakeLists.txt
+++ b/examples/Sqlpp11/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/SuiteSparse-dynLAPACK/CMakeLists.txt
+++ b/examples/SuiteSparse-dynLAPACK/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, NeroBurner
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
 

--- a/examples/SuiteSparse/CMakeLists.txt
+++ b/examples/SuiteSparse/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, NeroBurner
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/TCLAP/CMakeLists.txt
+++ b/examples/TCLAP/CMakeLists.txt
@@ -2,7 +2,7 @@
 # by Cyberunner23
 # for the Hunter project
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 variable_watch(HUNTER_TCLAP_VERSION)
 

--- a/examples/TIFF/CMakeLists.txt
+++ b/examples/TIFF/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Tesseract/CMakeLists.txt
+++ b/examples/Tesseract/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Sacha Refshauge
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Urho3D/CMakeLists.txt
+++ b/examples/Urho3D/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 

--- a/examples/Vulkan-Headers/CMakeLists.txt
+++ b/examples/Vulkan-Headers/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/VulkanMemoryAllocator/CMakeLists.txt
+++ b/examples/VulkanMemoryAllocator/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/WDC/CMakeLists.txt
+++ b/examples/WDC/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/WTL/CMakeLists.txt
+++ b/examples/WTL/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Alexander Lamaison
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Washer/CMakeLists.txt
+++ b/examples/Washer/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2015, Alexander Lamaison
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/WebKit/CMakeLists.txt
+++ b/examples/WebKit/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/WebP/CMakeLists.txt
+++ b/examples/WebP/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2018, Mathieu-Andre Chiasson
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/WinSparkle/CMakeLists.txt
+++ b/examples/WinSparkle/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2015, Alexander Lamaison
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/YAJL/CMakeLists.txt
+++ b/examples/YAJL/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ZLIB/CMakeLists.txt
+++ b/examples/ZLIB/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ZMQPP/CMakeLists.txt
+++ b/examples/ZMQPP/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ZeroMQ/CMakeLists.txt
+++ b/examples/ZeroMQ/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/Zug/CMakeLists.txt
+++ b/examples/Zug/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c)
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/cpp-pm/gate

--- a/examples/abseil/CMakeLists.txt
+++ b/examples/abseil/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/accelerate/CMakeLists.txt
+++ b/examples/accelerate/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/acf/CMakeLists.txt
+++ b/examples/acf/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/actionlib/CMakeLists.txt
+++ b/examples/actionlib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/aes/CMakeLists.txt
+++ b/examples/aes/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/aglet/CMakeLists.txt
+++ b/examples/aglet/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android/CMakeLists.txt
+++ b/examples/android/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_arm64_v8a_system_image_packer/CMakeLists.txt
+++ b/examples/android_arm64_v8a_system_image_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_arm_eabi_v7a_system_image_packer/CMakeLists.txt
+++ b/examples/android_arm_eabi_v7a_system_image_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_build_tools_packer/CMakeLists.txt
+++ b/examples/android_build_tools_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_google_apis_intel_x86_atom_system_image_packer/CMakeLists.txt
+++ b/examples/android_google_apis_intel_x86_atom_system_image_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_google_apis_packer/CMakeLists.txt
+++ b/examples/android_google_apis_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_google_repository_packer/CMakeLists.txt
+++ b/examples/android_google_repository_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_intel_x86_atom_system_image_packer/CMakeLists.txt
+++ b/examples/android_intel_x86_atom_system_image_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_log/CMakeLists.txt
+++ b/examples/android_log/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_mips_system_image_packer/CMakeLists.txt
+++ b/examples/android_mips_system_image_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_sdk_packer/CMakeLists.txt
+++ b/examples/android_sdk_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_sdk_platform_packer/CMakeLists.txt
+++ b/examples/android_sdk_platform_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_sdk_platform_tools_packer/CMakeLists.txt
+++ b/examples/android_sdk_platform_tools_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_sdk_tools_packer/CMakeLists.txt
+++ b/examples/android_sdk_tools_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/android_support_repository_packer/CMakeLists.txt
+++ b/examples/android_support_repository_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/angles/CMakeLists.txt
+++ b/examples/angles/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/apg/CMakeLists.txt
+++ b/examples/apg/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/applicationservices/CMakeLists.txt
+++ b/examples/applicationservices/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/arabica/CMakeLists.txt
+++ b/examples/arabica/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/asio-grpc/CMakeLists.txt
+++ b/examples/asio-grpc/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/asio/CMakeLists.txt
+++ b/examples/asio/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Niall Douglas
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/cpp-pm/gate

--- a/examples/astc-encoder/CMakeLists.txt
+++ b/examples/astc-encoder/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/audiounit/CMakeLists.txt
+++ b/examples/audiounit/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/autobahn-cpp/CMakeLists.txt
+++ b/examples/autobahn-cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/autoutils/CMakeLists.txt
+++ b/examples/autoutils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/aws-c-common/CMakeLists.txt
+++ b/examples/aws-c-common/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Ruslan Baratov, Rahul Sheth
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/aws-sdk-cpp/CMakeLists.txt
+++ b/examples/aws-sdk-cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/basis_universal/CMakeLists.txt
+++ b/examples/basis_universal/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/benchmark/CMakeLists.txt
+++ b/examples/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/bento4/CMakeLists.txt
+++ b/examples/bento4/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/binaryen/CMakeLists.txt
+++ b/examples/binaryen/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/bison/CMakeLists.txt
+++ b/examples/bison/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/boost-pba/CMakeLists.txt
+++ b/examples/boost-pba/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/botan/CMakeLists.txt
+++ b/examples/botan/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/bullet/CMakeLists.txt
+++ b/examples/bullet/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/byte-lite/CMakeLists.txt
+++ b/examples/byte-lite/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Niall Douglas
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/cpp-pm/gate

--- a/examples/c-ares/CMakeLists.txt
+++ b/examples/c-ares/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/caffe/CMakeLists.txt
+++ b/examples/caffe/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/carbon/CMakeLists.txt
+++ b/examples/carbon/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/catkin/CMakeLists.txt
+++ b/examples/catkin/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cctz/CMakeLists.txt
+++ b/examples/cctz/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/ccv/CMakeLists.txt
+++ b/examples/ccv/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cereal/CMakeLists.txt
+++ b/examples/cereal/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ceres-solver-suitesparse-dynLAPACK/CMakeLists.txt
+++ b/examples/ceres-solver-suitesparse-dynLAPACK/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
 

--- a/examples/ceres-solver-suitesparse/CMakeLists.txt
+++ b/examples/ceres-solver-suitesparse/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
 

--- a/examples/ceres-solver/CMakeLists.txt
+++ b/examples/ceres-solver/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cgltf/CMakeLists.txt
+++ b/examples/cgltf/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/check_ci_tag/CMakeLists.txt
+++ b/examples/check_ci_tag/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/chromium_zlib/CMakeLists.txt
+++ b/examples/chromium_zlib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/civetweb/CMakeLists.txt
+++ b/examples/civetweb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/clBLAS/CMakeLists.txt
+++ b/examples/clBLAS/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/class_loader/CMakeLists.txt
+++ b/examples/class_loader/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cmcstl2/CMakeLists.txt
+++ b/examples/cmcstl2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/common.cmake
+++ b/examples/common.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, 2015 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 ### Include HunterGate module from git submodule
 set(gate_dir "${CMAKE_CURRENT_LIST_DIR}/../gate")

--- a/examples/complex_bessel/CMakeLists.txt
+++ b/examples/complex_bessel/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/convertutf/CMakeLists.txt
+++ b/examples/convertutf/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/coreaudio/CMakeLists.txt
+++ b/examples/coreaudio/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/coretext/CMakeLists.txt
+++ b/examples/coretext/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/corrade/CMakeLists.txt
+++ b/examples/corrade/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cpp-statsd-client/CMakeLists.txt
+++ b/examples/cpp-statsd-client/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cpp_redis/CMakeLists.txt
+++ b/examples/cpp_redis/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cppast/CMakeLists.txt
+++ b/examples/cppast/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cppcodec/CMakeLists.txt
+++ b/examples/cppcodec/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cppfs/CMakeLists.txt
+++ b/examples/cppfs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cpr/CMakeLists.txt
+++ b/examples/cpr/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cpuinfo/CMakeLists.txt
+++ b/examples/cpuinfo/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/crashpad/CMakeLists.txt
+++ b/examples/crashpad/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/crashup/CMakeLists.txt
+++ b/examples/crashup/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/crc32c/CMakeLists.txt
+++ b/examples/crc32c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/cryptopp/CMakeLists.txt
+++ b/examples/cryptopp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ctti/CMakeLists.txt
+++ b/examples/ctti/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cub/CMakeLists.txt
+++ b/examples/cub/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cvmatio/CMakeLists.txt
+++ b/examples/cvmatio/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cvsteer/CMakeLists.txt
+++ b/examples/cvsteer/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2018, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/cxxopts/CMakeLists.txt
+++ b/examples/cxxopts/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/damageproto/CMakeLists.txt
+++ b/examples/damageproto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/date/CMakeLists.txt
+++ b/examples/date/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/dest/CMakeLists.txt
+++ b/examples/dest/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/dfdutils/CMakeLists.txt
+++ b/examples/dfdutils/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/dlib-staticLib/CMakeLists.txt
+++ b/examples/dlib-staticLib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/dlib/CMakeLists.txt
+++ b/examples/dlib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/dlpack/CMakeLists.txt
+++ b/examples/dlpack/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/dmlc-core/CMakeLists.txt
+++ b/examples/dmlc-core/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2018, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/doctest/CMakeLists.txt
+++ b/examples/doctest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/double-conversion/CMakeLists.txt
+++ b/examples/double-conversion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/draco/CMakeLists.txt
+++ b/examples/draco/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/dri2proto/CMakeLists.txt
+++ b/examples/dri2proto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/dri3proto/CMakeLists.txt
+++ b/examples/dri3proto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/drishti/CMakeLists.txt
+++ b/examples/drishti/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
 

--- a/examples/drishti_assets/CMakeLists.txt
+++ b/examples/drishti_assets/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/drishti_faces/CMakeLists.txt
+++ b/examples/drishti_faces/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/drm/CMakeLists.txt
+++ b/examples/drm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/duktape/CMakeLists.txt
+++ b/examples/duktape/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/dynalo/CMakeLists.txt
+++ b/examples/dynalo/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2018, Yassine Maddouri
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/egl/CMakeLists.txt
+++ b/examples/egl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/eigen3-nnls/CMakeLists.txt
+++ b/examples/eigen3-nnls/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/enet/CMakeLists.txt
+++ b/examples/enet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/entityx/CMakeLists.txt
+++ b/examples/entityx/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/eos/CMakeLists.txt
+++ b/examples/eos/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/etc2comp/CMakeLists.txt
+++ b/examples/etc2comp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ethash/CMakeLists.txt
+++ b/examples/ethash/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/eventpp/CMakeLists.txt
+++ b/examples/eventpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2022
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/farmhash/CMakeLists.txt
+++ b/examples/farmhash/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/fast_obj/CMakeLists.txt
+++ b/examples/fast_obj/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ffmpeg/CMakeLists.txt
+++ b/examples/ffmpeg/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/fft2d/CMakeLists.txt
+++ b/examples/fft2d/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/filament/CMakeLists.txt
+++ b/examples/filament/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/fixesproto/CMakeLists.txt
+++ b/examples/fixesproto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/flatbuffers/CMakeLists.txt
+++ b/examples/flatbuffers/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/flex/CMakeLists.txt
+++ b/examples/flex/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/fmt/CMakeLists.txt
+++ b/examples/fmt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/folly/CMakeLists.txt
+++ b/examples/folly/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/foo/CMakeLists.txt
+++ b/examples/foo/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/forcefeedback/CMakeLists.txt
+++ b/examples/forcefeedback/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/foundation/CMakeLists.txt
+++ b/examples/foundation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/freetype-gl/CMakeLists.txt
+++ b/examples/freetype-gl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/freetype/CMakeLists.txt
+++ b/examples/freetype/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/frugally-deep/CMakeLists.txt
+++ b/examples/frugally-deep/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2018, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/gRPC/CMakeLists.txt
+++ b/examples/gRPC/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 include("../common.cmake")

--- a/examples/gauze/CMakeLists.txt
+++ b/examples/gauze/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/gemmlowp/CMakeLists.txt
+++ b/examples/gemmlowp/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/geos/CMakeLists.txt
+++ b/examples/geos/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/getopt/CMakeLists.txt
+++ b/examples/getopt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/gflags/CMakeLists.txt
+++ b/examples/gflags/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/giflib/CMakeLists.txt
+++ b/examples/giflib/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/gl4es/CMakeLists.txt
+++ b/examples/gl4es/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/glapi/CMakeLists.txt
+++ b/examples/glapi/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/glbinding/CMakeLists.txt
+++ b/examples/glbinding/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, NeroBurner
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/gles2/CMakeLists.txt
+++ b/examples/gles2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/gles3/CMakeLists.txt
+++ b/examples/gles3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/glew/CMakeLists.txt
+++ b/examples/glew/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2016, Alexandre Pretyman
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/glfw/CMakeLists.txt
+++ b/examples/glfw/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2016, Alexandre Pretyman
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/glib/CMakeLists.txt
+++ b/examples/glib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/glm/CMakeLists.txt
+++ b/examples/glm/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2016, Alexandre Pretyman
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/globjects/CMakeLists.txt
+++ b/examples/globjects/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, NeroBurner
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 

--- a/examples/glog/CMakeLists.txt
+++ b/examples/glog/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/glproto/CMakeLists.txt
+++ b/examples/glproto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/glslang/CMakeLists.txt
+++ b/examples/glslang/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/glu/CMakeLists.txt
+++ b/examples/glu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/gsl-lite/CMakeLists.txt
+++ b/examples/gsl-lite/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Niall Douglas
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/cpp-pm/gate

--- a/examples/gst_plugins_bad/CMakeLists.txt
+++ b/examples/gst_plugins_bad/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/gst_plugins_base/CMakeLists.txt
+++ b/examples/gst_plugins_base/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/gst_plugins_good/CMakeLists.txt
+++ b/examples/gst_plugins_good/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/gst_plugins_ugly/CMakeLists.txt
+++ b/examples/gst_plugins_ugly/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/gstreamer/CMakeLists.txt
+++ b/examples/gstreamer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/gumbo/CMakeLists.txt
+++ b/examples/gumbo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/h3/CMakeLists.txt
+++ b/examples/h3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/half/CMakeLists.txt
+++ b/examples/half/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/harfbuzz/CMakeLists.txt
+++ b/examples/harfbuzz/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/hdf5/CMakeLists.txt
+++ b/examples/hdf5/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Oliver Daniell
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/highwayhash/CMakeLists.txt
+++ b/examples/highwayhash/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/http-parser/CMakeLists.txt
+++ b/examples/http-parser/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/hypre/CMakeLists.txt
+++ b/examples/hypre/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ice/CMakeLists.txt
+++ b/examples/ice/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/icu-le-hb/CMakeLists.txt
+++ b/examples/icu-le-hb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/icu-lx/CMakeLists.txt
+++ b/examples/icu-lx/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/imagequant/CMakeLists.txt
+++ b/examples/imagequant/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/imgui/CMakeLists.txt
+++ b/examples/imgui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/imshow/CMakeLists.txt
+++ b/examples/imshow/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/inja/CMakeLists.txt
+++ b/examples/inja/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/inputproto/CMakeLists.txt
+++ b/examples/inputproto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/intsizeof/CMakeLists.txt
+++ b/examples/intsizeof/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/intx/CMakeLists.txt
+++ b/examples/intx/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Pawel Bylica
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ippicv/CMakeLists.txt
+++ b/examples/ippicv/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/iroha-ed25519/CMakeLists.txt
+++ b/examples/iroha-ed25519/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/irrXML/CMakeLists.txt
+++ b/examples/irrXML/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ittapi/CMakeLists.txt
+++ b/examples/ittapi/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/jaegertracing/CMakeLists.txt
+++ b/examples/jaegertracing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/jansson/CMakeLists.txt
+++ b/examples/jansson/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/jasper/CMakeLists.txt
+++ b/examples/jasper/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/javascriptcore/CMakeLists.txt
+++ b/examples/javascriptcore/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/jo_jpeg/CMakeLists.txt
+++ b/examples/jo_jpeg/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/jpeg-compressor/CMakeLists.txt
+++ b/examples/jpeg-compressor/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/jsmn/CMakeLists.txt
+++ b/examples/jsmn/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/jsoncpp/CMakeLists.txt
+++ b/examples/jsoncpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/jwt-cpp/CMakeLists.txt
+++ b/examples/jwt-cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/kNet/CMakeLists.txt
+++ b/examples/kNet/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/kbproto/CMakeLists.txt
+++ b/examples/kbproto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/lcms/CMakeLists.txt
+++ b/examples/lcms/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/lehrfempp/CMakeLists.txt
+++ b/examples/lehrfempp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/leveldb/CMakeLists.txt
+++ b/examples/leveldb/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/libarchive/CMakeLists.txt
+++ b/examples/libarchive/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Timothy Stack
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libbacktrace/CMakeLists.txt
+++ b/examples/libbacktrace/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c)
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/cpp-pm/gate

--- a/examples/libcpuid/CMakeLists.txt
+++ b/examples/libcpuid/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libdill/CMakeLists.txt
+++ b/examples/libdill/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/libevhtp/CMakeLists.txt
+++ b/examples/libevhtp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/libffi/CMakeLists.txt
+++ b/examples/libffi/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libigl/CMakeLists.txt
+++ b/examples/libigl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libjpeg-turbo/CMakeLists.txt
+++ b/examples/libjpeg-turbo/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libjson-rpc-cpp/CMakeLists.txt
+++ b/examples/libjson-rpc-cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libmill/CMakeLists.txt
+++ b/examples/libmill/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/libogg/CMakeLists.txt
+++ b/examples/libogg/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libpcre/CMakeLists.txt
+++ b/examples/libpcre/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/librtmp/CMakeLists.txt
+++ b/examples/librtmp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libscrypt/CMakeLists.txt
+++ b/examples/libscrypt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libsodium/CMakeLists.txt
+++ b/examples/libsodium/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libunibreak/CMakeLists.txt
+++ b/examples/libunibreak/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libusb/CMakeLists.txt
+++ b/examples/libusb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libuv/CMakeLists.txt
+++ b/examples/libuv/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Aaditya Kalsi
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libxdg-basedir/CMakeLists.txt
+++ b/examples/libxdg-basedir/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/libxml2/CMakeLists.txt
+++ b/examples/libxml2/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2016, Alexandre Pretyman
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libyuv/CMakeLists.txt
+++ b/examples/libyuv/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/libzip/CMakeLists.txt
+++ b/examples/libzip/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/lmdb/CMakeLists.txt
+++ b/examples/lmdb/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/lmdbxx/CMakeLists.txt
+++ b/examples/lmdbxx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/log4cplus/CMakeLists.txt
+++ b/examples/log4cplus/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/lss/CMakeLists.txt
+++ b/examples/lss/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/lz4/CMakeLists.txt
+++ b/examples/lz4/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/lzma/CMakeLists.txt
+++ b/examples/lzma/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/magnum/CMakeLists.txt
+++ b/examples/magnum/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/md5/CMakeLists.txt
+++ b/examples/md5/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/meshoptimizer/CMakeLists.txt
+++ b/examples/meshoptimizer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/mini_chromium/CMakeLists.txt
+++ b/examples/mini_chromium/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/miniz/CMakeLists.txt
+++ b/examples/miniz/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/minizip/CMakeLists.txt
+++ b/examples/minizip/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/mkl/CMakeLists.txt
+++ b/examples/mkl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/mkldnn/CMakeLists.txt
+++ b/examples/mkldnn/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/mng/CMakeLists.txt
+++ b/examples/mng/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/mojoshader/CMakeLists.txt
+++ b/examples/mojoshader/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/mongoose/CMakeLists.txt
+++ b/examples/mongoose/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/mpark_variant/CMakeLists.txt
+++ b/examples/mpark_variant/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/msgpack/CMakeLists.txt
+++ b/examples/msgpack/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/mshadow/CMakeLists.txt
+++ b/examples/mshadow/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/mtplz/CMakeLists.txt
+++ b/examples/mtplz/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/mxnet/CMakeLists.txt
+++ b/examples/mxnet/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 

--- a/examples/nanoflann/CMakeLists.txt
+++ b/examples/nanoflann/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/nanosvg/CMakeLists.txt
+++ b/examples/nanosvg/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate
 include("../common.cmake")

--- a/examples/ncnn/CMakeLists.txt
+++ b/examples/ncnn/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2018, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ncursesw/CMakeLists.txt
+++ b/examples/ncursesw/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/nlohmann_fifo_map/CMakeLists.txt
+++ b/examples/nlohmann_fifo_map/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/nng/CMakeLists.txt
+++ b/examples/nng/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/nsync/CMakeLists.txt
+++ b/examples/nsync/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/occt/CMakeLists.txt
+++ b/examples/occt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/odb-boost/CMakeLists.txt
+++ b/examples/odb-boost/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2016, Alexandre Pretyman
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/odb-compiler/CMakeLists.txt
+++ b/examples/odb-compiler/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/odb-mysql/CMakeLists.txt
+++ b/examples/odb-mysql/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2016, Alexandre Pretyman
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/odb-pgsql/CMakeLists.txt
+++ b/examples/odb-pgsql/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2016, Alexandre Pretyman
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/odb-sqlite/CMakeLists.txt
+++ b/examples/odb-sqlite/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/odb/CMakeLists.txt
+++ b/examples/odb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ogles_gpgpu/CMakeLists.txt
+++ b/examples/ogles_gpgpu/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/oneTBB/CMakeLists.txt
+++ b/examples/oneTBB/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2022, Raffael Casagrande
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/oniguruma/CMakeLists.txt
+++ b/examples/oniguruma/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/onmt/CMakeLists.txt
+++ b/examples/onmt/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/openddlparser/CMakeLists.txt
+++ b/examples/openddlparser/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/opengles/CMakeLists.txt
+++ b/examples/opengles/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/opentracing-cpp/CMakeLists.txt
+++ b/examples/opentracing-cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/opusfile/CMakeLists.txt
+++ b/examples/opusfile/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/osmesa/CMakeLists.txt
+++ b/examples/osmesa/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/pcg/CMakeLists.txt
+++ b/examples/pcg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/pciaccess/CMakeLists.txt
+++ b/examples/pciaccess/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/pcre2/CMakeLists.txt
+++ b/examples/pcre2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/pegtl/CMakeLists.txt
+++ b/examples/pegtl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/pluginlib/CMakeLists.txt
+++ b/examples/pluginlib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/poly2tri/CMakeLists.txt
+++ b/examples/poly2tri/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/polyclipping/CMakeLists.txt
+++ b/examples/polyclipping/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/presentproto/CMakeLists.txt
+++ b/examples/presentproto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/prometheus-cpp/CMakeLists.txt
+++ b/examples/prometheus-cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/protobuf-c/CMakeLists.txt
+++ b/examples/protobuf-c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/pthread-stubs/CMakeLists.txt
+++ b/examples/pthread-stubs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/pthreads-win32/CMakeLists.txt
+++ b/examples/pthreads-win32/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/pugixml/CMakeLists.txt
+++ b/examples/pugixml/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/pybind11/CMakeLists.txt
+++ b/examples/pybind11/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/qhull/CMakeLists.txt
+++ b/examples/qhull/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/qt-camera/CMakeLists.txt
+++ b/examples/qt-camera/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
 

--- a/examples/qt-core/CMakeLists.txt
+++ b/examples/qt-core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/qt-location/CMakeLists.txt
+++ b/examples/qt-location/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/qt-qml/CMakeLists.txt
+++ b/examples/qt-qml/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/qt-widgets/CMakeLists.txt
+++ b/examples/qt-widgets/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Simple Qt Widgets project created by QtCreator
 # CmakeLists.txt from http://doc.qt.io/qt-5/cmake-manual.html
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/quickjs/CMakeLists.txt
+++ b/examples/quickjs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/rabbitmq-c/CMakeLists.txt
+++ b/examples/rabbitmq-c/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/rabit/CMakeLists.txt
+++ b/examples/rabit/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2017, David Hirvonen
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/randrproto/CMakeLists.txt
+++ b/examples/randrproto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/rang/CMakeLists.txt
+++ b/examples/rang/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/range-v3/CMakeLists.txt
+++ b/examples/range-v3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/re2/CMakeLists.txt
+++ b/examples/re2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Ruslan Baratov, David Hirvonen, Rahul Sheth
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/readline/CMakeLists.txt
+++ b/examples/readline/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/recastnavigation/CMakeLists.txt
+++ b/examples/recastnavigation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/renderproto/CMakeLists.txt
+++ b/examples/renderproto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/rocksdb/CMakeLists.txt
+++ b/examples/rocksdb/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros/CMakeLists.txt
+++ b/examples/ros/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_comm/CMakeLists.txt
+++ b/examples/ros_comm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_comm_msgs/CMakeLists.txt
+++ b/examples/ros_comm_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_common_msgs/CMakeLists.txt
+++ b/examples/ros_common_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_console_bridge/CMakeLists.txt
+++ b/examples/ros_console_bridge/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_environment/CMakeLists.txt
+++ b/examples/ros_environment/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_gencpp/CMakeLists.txt
+++ b/examples/ros_gencpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_geneus/CMakeLists.txt
+++ b/examples/ros_geneus/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_genlisp/CMakeLists.txt
+++ b/examples/ros_genlisp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_genmsg/CMakeLists.txt
+++ b/examples/ros_genmsg/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_gennodejs/CMakeLists.txt
+++ b/examples/ros_gennodejs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_genpy/CMakeLists.txt
+++ b/examples/ros_genpy/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_message_generation/CMakeLists.txt
+++ b/examples/ros_message_generation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_message_runtime/CMakeLists.txt
+++ b/examples/ros_message_runtime/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/ros_std_msgs/CMakeLists.txt
+++ b/examples/ros_std_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/rosconsole/CMakeLists.txt
+++ b/examples/rosconsole/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/roscpp_core/CMakeLists.txt
+++ b/examples/roscpp_core/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/rospack/CMakeLists.txt
+++ b/examples/rospack/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/s3/CMakeLists.txt
+++ b/examples/s3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/scelta/CMakeLists.txt
+++ b/examples/scelta/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c)
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/cpp-pm/gate

--- a/examples/sds/CMakeLists.txt
+++ b/examples/sds/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/sentencepiece/CMakeLists.txt
+++ b/examples/sentencepiece/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/sentry/CMakeLists.txt
+++ b/examples/sentry/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/shaderc/CMakeLists.txt
+++ b/examples/shaderc/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/shaka_player_embedded/CMakeLists.txt
+++ b/examples/shaka_player_embedded/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 

--- a/examples/sleef/CMakeLists.txt
+++ b/examples/sleef/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/sm/CMakeLists.txt
+++ b/examples/sm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/smol-v/CMakeLists.txt
+++ b/examples/smol-v/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/soil/CMakeLists.txt
+++ b/examples/soil/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/sources_for_android_sdk_packer/CMakeLists.txt
+++ b/examples/sources_for_android_sdk_packer/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/spdlog/CMakeLists.txt
+++ b/examples/spdlog/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/spirv-cross/CMakeLists.txt
+++ b/examples/spirv-cross/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/sqlite3/CMakeLists.txt
+++ b/examples/sqlite3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/sse2neon/CMakeLists.txt
+++ b/examples/sse2neon/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/stanhull/CMakeLists.txt
+++ b/examples/stanhull/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/state_machine/CMakeLists.txt
+++ b/examples/state_machine/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/stb/CMakeLists.txt
+++ b/examples/stb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/stdext-path/CMakeLists.txt
+++ b/examples/stdext-path/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/stormlib/CMakeLists.txt
+++ b/examples/stormlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/sugar/CMakeLists.txt
+++ b/examples/sugar/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2013, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/szip/CMakeLists.txt
+++ b/examples/szip/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Oliver Daniell
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tacopie/CMakeLists.txt
+++ b/examples/tacopie/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/taocpp-json/CMakeLists.txt
+++ b/examples/taocpp-json/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/taskflow/CMakeLists.txt
+++ b/examples/taskflow/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tcl/CMakeLists.txt
+++ b/examples/tcl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tf/CMakeLists.txt
+++ b/examples/tf/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tf2/CMakeLists.txt
+++ b/examples/tf2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/theora/CMakeLists.txt
+++ b/examples/theora/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c)
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/cpp-pm/gate

--- a/examples/thread-pool-cpp/CMakeLists.txt
+++ b/examples/thread-pool-cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/thrift/CMakeLists.txt
+++ b/examples/thrift/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/tiny-process-library/CMakeLists.txt
+++ b/examples/tiny-process-library/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tinydir/CMakeLists.txt
+++ b/examples/tinydir/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tinyexr/CMakeLists.txt
+++ b/examples/tinyexr/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tinygltf/CMakeLists.txt
+++ b/examples/tinygltf/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tinyobjloader/CMakeLists.txt
+++ b/examples/tinyobjloader/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2020, Rahul Sheth
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tinyrefl/CMakeLists.txt
+++ b/examples/tinyrefl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tinyxml2/CMakeLists.txt
+++ b/examples/tinyxml2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tmxparser/CMakeLists.txt
+++ b/examples/tmxparser/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/toluapp/CMakeLists.txt
+++ b/examples/toluapp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
 

--- a/examples/tomcrypt/CMakeLists.txt
+++ b/examples/tomcrypt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tommath/CMakeLists.txt
+++ b/examples/tommath/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tsl_hat_trie/CMakeLists.txt
+++ b/examples/tsl_hat_trie/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tsl_robin_map/CMakeLists.txt
+++ b/examples/tsl_robin_map/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/tvm/CMakeLists.txt
+++ b/examples/tvm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 set(TESTING_CONFIG_OPT FILEPATH ${CMAKE_CURRENT_LIST_DIR}/config.cmake)
 

--- a/examples/uriparser/CMakeLists.txt
+++ b/examples/uriparser/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/utf8/CMakeLists.txt
+++ b/examples/utf8/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/util_linux/CMakeLists.txt
+++ b/examples/util_linux/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/uuid/CMakeLists.txt
+++ b/examples/uuid/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c)
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/cpp-pm/gate

--- a/examples/v8/CMakeLists.txt
+++ b/examples/v8/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/vectorial/CMakeLists.txt
+++ b/examples/vectorial/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/videotoolbox/CMakeLists.txt
+++ b/examples/videotoolbox/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/vorbis/CMakeLists.txt
+++ b/examples/vorbis/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/vurtun-lib/CMakeLists.txt
+++ b/examples/vurtun-lib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/websocketpp/CMakeLists.txt
+++ b/examples/websocketpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../common.cmake")
 

--- a/examples/wt/CMakeLists.txt
+++ b/examples/wt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/wxWidgets/CMakeLists.txt
+++ b/examples/wxWidgets/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2015, Alexander Lamaison
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/wyrm/CMakeLists.txt
+++ b/examples/wyrm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/x11/CMakeLists.txt
+++ b/examples/x11/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/x264/CMakeLists.txt
+++ b/examples/x264/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2017, Alexandre Pretyman
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xatlas/CMakeLists.txt
+++ b/examples/xatlas/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2020, Rahul Sheth, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xau/CMakeLists.txt
+++ b/examples/xau/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xcb-proto/CMakeLists.txt
+++ b/examples/xcb-proto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xcb/CMakeLists.txt
+++ b/examples/xcb/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xcursor/CMakeLists.txt
+++ b/examples/xcursor/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xdamage/CMakeLists.txt
+++ b/examples/xdamage/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xext/CMakeLists.txt
+++ b/examples/xext/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xextproto/CMakeLists.txt
+++ b/examples/xextproto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xf86vidmodeproto/CMakeLists.txt
+++ b/examples/xf86vidmodeproto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xfixes/CMakeLists.txt
+++ b/examples/xfixes/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xgboost/CMakeLists.txt
+++ b/examples/xgboost/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xi/CMakeLists.txt
+++ b/examples/xi/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2017, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xinerama/CMakeLists.txt
+++ b/examples/xinerama/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xineramaproto/CMakeLists.txt
+++ b/examples/xineramaproto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xorg-macros/CMakeLists.txt
+++ b/examples/xorg-macros/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xproto/CMakeLists.txt
+++ b/examples/xproto/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xrandr/CMakeLists.txt
+++ b/examples/xrandr/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xrender/CMakeLists.txt
+++ b/examples/xrender/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xshmfence/CMakeLists.txt
+++ b/examples/xshmfence/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xtrans/CMakeLists.txt
+++ b/examples/xtrans/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xxf86vm/CMakeLists.txt
+++ b/examples/xxf86vm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/xxhash/CMakeLists.txt
+++ b/examples/xxhash/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2018, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/yaml-cpp/CMakeLists.txt
+++ b/examples/yaml-cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/zip/CMakeLists.txt
+++ b/examples/zip/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/zlog/CMakeLists.txt
+++ b/examples/zlog/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2019, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/zookeeper/CMakeLists.txt
+++ b/examples/zookeeper/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/hunter-packages/gate

--- a/examples/zstd/CMakeLists.txt
+++ b/examples/zstd/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Niall Douglas
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Emulate HunterGate:
 # * https://github.com/cpp-pm/gate

--- a/scripts/append-boost-config-macros.cmake.in
+++ b/scripts/append-boost-config-macros.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # run at the boost source root
 set(boost_user_config_file "boost/config/user.hpp")

--- a/scripts/autotools-merge-lipo.cmake.in
+++ b/scripts/autotools-merge-lipo.cmake.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, 2019 Ruslan Baratov, Alexandre Pretyman
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 ### Input params check
 

--- a/scripts/clean-boost-configs.cmake
+++ b/scripts/clean-boost-configs.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 if("${installdir}" STREQUAL "")
   message(FATAL_ERROR "installdir is empty")

--- a/scripts/create-toolchain-info.cmake
+++ b/scripts/create-toolchain-info.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(HunterToolchain)
 
 if(NOT HUNTER_SELF)

--- a/scripts/find_python.cmake
+++ b/scripts/find_python.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
   find_package(PythonInterp 3 QUIET)

--- a/scripts/link-all.cmake
+++ b/scripts/link-all.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 string(COMPARE EQUAL "${HUNTER_INSTALL_PREFIX}" "" is_empty)
 if(is_empty)

--- a/scripts/try-copy-license.cmake
+++ b/scripts/try-copy-license.cmake
@@ -2,7 +2,7 @@
 # Copyright (c) 2017 Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 string(COMPARE EQUAL "${srcdir}" "" is_empty)
 if(is_empty)

--- a/tests/append-boost-config-macros/CMakeLists.txt
+++ b/tests/append-boost-config-macros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 include(hunter_parse_boost_config_macros)

--- a/tests/autotools-merge-lipo/CMakeLists.txt
+++ b/tests/autotools-merge-lipo/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestAutotoolsMergeLipo)

--- a/tests/hunter_check_toolchain_definition/CMakeLists.txt
+++ b/tests/hunter_check_toolchain_definition/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterCheckToolchainDefinition)

--- a/tests/hunter_create_args_file/CMakeLists.txt
+++ b/tests/hunter_create_args_file/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterCreateArgsFile)

--- a/tests/hunter_create_dependency_entry/CMakeLists.txt
+++ b/tests/hunter_create_dependency_entry/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterCreateDependencyEntry)

--- a/tests/hunter_create_deps_info/CMakeLists.txt
+++ b/tests/hunter_create_deps_info/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterCreateDepsInfo)

--- a/tests/hunter_download_cache_meta_file/CMakeLists.txt
+++ b/tests/hunter_download_cache_meta_file/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterDownloadCacheMetaFile)

--- a/tests/hunter_download_cache_raw_file/CMakeLists.txt
+++ b/tests/hunter_download_cache_raw_file/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterDownloadCacheRawFile)

--- a/tests/hunter_generate_qt_info/CMakeLists.txt
+++ b/tests/hunter_generate_qt_info/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterGenerateQtInfo)

--- a/tests/hunter_get_package_deps/CMakeLists.txt
+++ b/tests/hunter_get_package_deps/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterGetPackageDeps)

--- a/tests/hunter_get_package_deps_recurse/CMakeLists.txt
+++ b/tests/hunter_get_package_deps_recurse/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterGetPackageDepsRecurse)

--- a/tests/hunter_init_not_found_counter/CMakeLists.txt
+++ b/tests/hunter_init_not_found_counter/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterHunterInitNotFoundCounter)

--- a/tests/hunter_pack_directory/CMakeLists.txt
+++ b/tests/hunter_pack_directory/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterPackDirectory)

--- a/tests/hunter_register_dependency/CMakeLists.txt
+++ b/tests/hunter_register_dependency/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterRegisterDependency)

--- a/tests/hunter_setup_msvc/CMakeLists.txt
+++ b/tests/hunter_setup_msvc/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterSetupMsvcArch)

--- a/tests/hunter_sleep_before_download/CMakeLists.txt
+++ b/tests/hunter_sleep_before_download/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterSleepBeforeDownload)

--- a/tests/hunter_standard_flag/CMakeLists.txt
+++ b/tests/hunter_standard_flag/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Pawel Bylica
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 

--- a/tests/hunter_unpack_directory/CMakeLists.txt
+++ b/tests/hunter_unpack_directory/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 project(TestModuleHunterUnPackDirectory)

--- a/tests/issue/107/CMakeLists.txt
+++ b/tests/issue/107/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 set(OLD_UNIX "${UNIX}")
 set(OLD_WIN32 "${WIN32}")

--- a/tests/issue/109/unit/CMakeLists.txt
+++ b/tests/issue/109/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../../../examples/common.cmake")
 include(hunter_boost_component_b2_args)

--- a/tests/issue/22/CMakeLists.txt
+++ b/tests/issue/22/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../../examples/common.cmake")
 project(TestIssue22)

--- a/tests/issue/24/unit/CMakeLists.txt
+++ b/tests/issue/24/unit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../../../examples/common.cmake")
 

--- a/tests/simple/CMakeLists.txt
+++ b/tests/simple/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2014, Ruslan Baratov
 # All rights reserved.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 include("../../examples/common.cmake")
 


### PR DESCRIPTION
Replace all "cmake_minimum_required" for cmake versions prior to 3.5 with 3.5 itself - reflecting soon to be the minimum version that cmake supports.

This relates to Issue #685 

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). Yes
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). Yes
* My change will work with CMake 3.2 (minimum requirement for Hunter). No
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. Yes

