### PR TITLE
ceres-solver: update to v2.2.0-p0 and fix examples

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -219,7 +219,14 @@ hunter_default_version(catkin VERSION 0.7.17-p0)
 hunter_default_version(cctz VERSION 2.2.0)
 hunter_default_version(ccv VERSION 0.7-p6)
 hunter_default_version(cereal VERSION 1.2.2-p0)
-hunter_default_version(ceres-solver VERSION 2.1.0-p1)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0")
+  # Ubuntu 18.04 GCC compiler isn't C++17 conformant enough, stay at lower version
+  # - Ubuntu 18.04 disablement: https://github.com/ceres-solver/ceres-solver/commit/40c1a7e18ee040261f87b32374c9a46724ca2214
+  # - C++17 requirement: https://github.com/ceres-solver/ceres-solver/commit/1274743609bc59621adc9e311cdeeaad7eb65201
+  hunter_default_version(ceres-solver VERSION 2.1.0-p1)
+else()
+  hunter_default_version(ceres-solver VERSION 2.2.0-p0)
+endif()
 hunter_default_version(cgltf VERSION 1.10-f9a8804-p0)
 hunter_default_version(check_ci_tag VERSION 1.0.0)
 hunter_default_version(chromium_zlib VERSION 0.0.0-f87c2b10efb4-p0)

--- a/cmake/projects/ceres-solver/hunter.cmake
+++ b/cmake/projects/ceres-solver/hunter.cmake
@@ -98,15 +98,28 @@ hunter_add_version(
     8b14c6f33af3ef0595094cee2e6567681a481737
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    ceres-solver
+    VERSION
+    "2.2.0-p0"
+    URL
+    "https://github.com/cpp-pm/ceres-solver/archive/refs/tags/v2.2.0-p0.tar.gz"
+    SHA1
+    34500d5f4f536d5ea12740d04c6f0a086a735ccb
+)
+
 hunter_cmake_args(ceres-solver CMAKE_ARGS
     # explicitly remove dependency on gflags (only needed for tests)
     GFLAGS=OFF
     # explicitly disable suitesparse support
     LAPACK=OFF
     SUITESPARSE=OFF
-    CXSPARSE=OFF # since 1.14.0-p0
+    CXSPARSE=OFF # since 1.14.0-p0, option removed with v2.2.0-p0
     # user must explicitly opt in to compile wit CUDA support, since v2.1.0-p0
     CUDA=OFF
+    # CUDA keyword renamed to USE_CUDA since v2.2.0
+    USE_CUDA=OFF
     # OpenBLAS flag, alternative to LAPACK since v2.1.0-p0
     WITH_OPENBLAS=OFF
     # don't build tests

--- a/examples/ceres-solver-suitesparse-dynLAPACK/config.cmake
+++ b/examples/ceres-solver-suitesparse-dynLAPACK/config.cmake
@@ -2,7 +2,6 @@ hunter_config(ceres-solver
   VERSION ${HUNTER_ceres-solver_VERSION} CMAKE_ARGS
     LAPACK=ON
     SUITESPARSE=ON
-    CXSPARSE=OFF # since 1.14.0-p1
     WITH_OPENBLAS=OFF # we want to test generic LAPACK dynamic lib, not OpenBLAS
 )
 hunter_config(SuiteSparse

--- a/examples/ceres-solver-suitesparse/CMakeLists.txt
+++ b/examples/ceres-solver-suitesparse/CMakeLists.txt
@@ -10,14 +10,7 @@ set(TESTING_CONFIG_OPT FILEPATH "${CMAKE_CURRENT_LIST_DIR}/config.cmake")
 include("../common.cmake")
 
 project(download-ceres-solver)
-# enable Fortran support, needed for LAPACK static libs
-enable_language(Fortran)
-# as alternative LAPACK can be built as shared lib by adding
-# the following lines to config.cmake (uncommented)
-#hunter_config(LAPACK
-#  VERSION ${HUNTER_LAPACK_VERSION}
-#  CMAKE_ARGS BUILD_SHARED_LIBS=ON
-#)
+# using OpenBLAS instead of Fortran based LAPACK, no fortran needed since 2.1.0-p0
 
 hunter_add_package(ceres-solver)
 

--- a/examples/ceres-solver-suitesparse/config.cmake
+++ b/examples/ceres-solver-suitesparse/config.cmake
@@ -1,8 +1,6 @@
 hunter_config(ceres-solver
   VERSION ${HUNTER_ceres-solver_VERSION} CMAKE_ARGS
-    LAPACK=ON
     SUITESPARSE=ON
-    CXSPARSE=ON # since 1.14.0-p1
-    # sine 2.1.0, SuiteSparse 5.4.0 per default builds against OpenBLAS as well
+    # since 2.1.0, SuiteSparse 5.4.0 per default builds against OpenBLAS as well
     WITH_OPENBLAS=ON
 )


### PR DESCRIPTION
Update examples using SuiteSparse, building with OpenBLAS per default, ant one testing with dynamic-LAPACK package.

On older GCC versions like 7.5 from Ubuntu 18.04 bionic fall back to older ceres-solver `2.1.0-p1` version, as `2.2.0` needs a fully C++17 compliant compiler.

- Ubuntu 18.04 disablement: https://github.com/ceres-solver/ceres-solver/commit/40c1a7e18ee040261f87b32374c9a46724ca2214
- C++17 requirement: https://github.com/ceres-solver/ceres-solver/commit/1274743609bc59621adc9e311cdeeaad7eb65201

Fix the `CUDA=OFF` option, as it was renamed to `USE_CUDA`. Still disable both.
