### PR TITLE
Eigen: explicitly disable Fortran usage

### DIFF
--- a/cmake/projects/Eigen/hunter.cmake
+++ b/cmake/projects/Eigen/hunter.cmake
@@ -198,7 +198,11 @@ endif()
 hunter_cmake_args(
     Eigen
     CMAKE_ARGS
+    # explicitly disable gfortran usage
+    CMAKE_Fortran_COMPILER=NOTFOUND
+    # no need for tests or docs to save build-time
     BUILD_TESTING=OFF
+    EIGEN_BUILD_DOC=OFF
     HUNTER_INSTALL_LICENSE_FILES=COPYING.MPL2
     ${_android_args}
 )


### PR DESCRIPTION
We don't want different packages be created wheter a Fortran compiler is available or not. As Eigen 3.4.0 has no flags to disable the Fortran related code hook into the
[CheckLanguge](https://cmake.org/cmake/help/latest/module/CheckLanguage.html) CMake feature.

For the variable `CMAKE_<LANG>_COMPILER` the documentation states the following:

> If this variable is already set, either explicitly or cached by a previous
> call, the check is skipped.

We use this to effectively force Eigen to think that there was no Fortan compiler.

Fixes the ninja and nmake vs-16-2019 based toolchains.
