### PR TITLE
Update 'Boost' to 1.83

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -37,7 +37,7 @@ if(MINGW)
   # https://github.com/boostorg/build/issues/301
   hunter_default_version(Boost VERSION 1.64.0)
 else()
-  hunter_default_version(Boost VERSION 1.81.0)
+  hunter_default_version(Boost VERSION 1.83.0)
 endif()
 
 hunter_default_version(BoostCompute VERSION 0.5-p0)

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -490,9 +490,9 @@ hunter_add_version(
     VERSION
     "1.80.0"
     URL
-    "https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.7z"
+    "https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.bz2"
     SHA1
-    5463e5380ccd1564e57747969c9dcc852b82b237
+    690a2a2ed6861129828984b1d52a473d2c8393d1
 )
 
 hunter_add_version(
@@ -501,9 +501,31 @@ hunter_add_version(
     VERSION
     "1.81.0"
     URL
-    "https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.7z"
+    "https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2"
     SHA1
-    90bef80787606e1f4022a877073b2346636fdba3
+    898469f1ae407f5cbfca84f63ad602962eebf4cc
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.82.0"
+    URL
+    "https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2"
+    SHA1
+    5c0736ce8d6f0d21275a1d9407dce48e6decce6a
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.83.0"
+    URL
+    "https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2"
+    SHA1
+    75b1f569134401d178ad2aaf97a2993898dd7ee3
 )
 
 if(MSVC)

--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -13,6 +13,245 @@ include(hunter_check_toolchain_definition)
 # Disable searching in locations not specified by these hint variables.
 set(Boost_NO_SYSTEM_PATHS ON)
 
+# up until 1.63 sourcefourge was used, base url https://downloads.sourceforge.net/project/boost/boost
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.49.0"
+    URL
+    "http://sourceforge.net/projects/boost/files/boost/1.49.0/boost_1_49_0.tar.bz2/download"
+    SHA1
+    26a52840e9d12f829e3008589abf0a925ce88524
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.50.0"
+    URL
+    "http://sourceforge.net/projects/boost/files/boost/1.50.0/boost_1_50_0.tar.bz2/download"
+    SHA1
+    ee06f89ed472cf369573f8acf9819fbc7173344e
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.51.0"
+    URL
+    "http://sourceforge.net/projects/boost/files/boost/1.51.0/boost_1_51_0.tar.bz2/download"
+    SHA1
+    52ef06895b97cc9981b8abf1997c375ca79f30c5
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.52.0"
+    URL
+    "http://sourceforge.net/projects/boost/files/boost/1.52.0/boost_1_52_0.tar.bz2/download"
+    SHA1
+    cddd6b4526a09152ddc5db856463eaa1dc29c5d9
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.53.0"
+    URL
+    "http://sourceforge.net/projects/boost/files/boost/1.53.0/boost_1_53_0.tar.bz2/download"
+    SHA1
+    e6dd1b62ceed0a51add3dda6f3fc3ce0f636a7f3
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.54.0"
+    URL
+    "http://sourceforge.net/projects/boost/files/boost/1.54.0/boost_1_54_0.tar.bz2/download"
+    SHA1
+    230782c7219882d0fab5f1effbe86edb85238bf4
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.55.0"
+    URL
+    "http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.bz2/download"
+    SHA1
+    cef9a0cc7084b1d639e06cd3bc34e4251524c840
+)
+
+# Workaround for: https://svn.boost.org/trac/boost/ticket/9610
+# http://boost.2283326.n4.nabble.com/config-clang-int128-support-td4653826.html
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.55.0-patched"
+    URL
+    "http://sourceforge.net/projects/hunter-packages/files/boost_1_55_0-patched.tar.bz2/download"
+    SHA1
+    308adf99dbdf0668c9695ff1da075a9e3b71be9d
+)
+
+# Apply fix for: https://svn.boost.org/trac/boost/ticket/9332
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.55.0-patched-2"
+    URL
+    "http://sourceforge.net/projects/hunter-packages/files/boost_1_55_0-patched-2.tar.bz2/download"
+    SHA1
+    38c0523dbd27ed6b363ad9255548e942d404b39e
+)
+
+# Remove docs and tests
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.55.0-patched-3"
+    URL
+    "https://github.com/hunter-packages/boost/archive/1.55.0-patched-3.tar.gz"
+    SHA1
+    4ae01023ac0dc68570fd1bbcf67cbcd839df04eb
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.56.0"
+    URL
+    "https://github.com/hunter-packages/boost/archive/v1.56.0.tar.gz"
+    SHA1
+    08a45c69e90e5ddc485b770a573dbace8e48932e
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.57.0"
+    URL
+    "https://github.com/hunter-packages/boost/archive/v1.57.0.tar.gz"
+    SHA1
+    9305649224848860664893342ac29709ebcf42f9
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.58.0"
+    URL
+    "http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2/download"
+    SHA1
+    2fc96c1651ac6fe9859b678b165bd78dc211e881
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.58.0-p0"
+    URL
+    "https://github.com/hunter-packages/boost/archive/v1.58.0-p0.tar.gz"
+    SHA1
+    0c3a2f284e85a61e2d2ccc1a6fdc8dc7a443ef67
+)
+
+# Version without tests and docs
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.58.0-p1"
+    URL
+    "https://github.com/hunter-packages/boost/archive/v1.58.0-p1.tar.gz"
+    SHA1
+    bc417f98b644f244121c0eb47e810b4c6a6277e8
+)
+
+# Version without tests and docs
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.59.0"
+    URL
+    "https://github.com/hunter-packages/boost/archive/v1.59.0.tar.gz"
+    SHA1
+    28db0e54f9e55ff1230903704836e035f7227fd5
+)
+
+# Version without tests and docs
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.60.0"
+    URL
+    "https://github.com/hunter-packages/boost/archive/v1.60.0.tar.gz"
+    SHA1
+    28a5b0f739114fde5d4ed1d7f52e5b6cf13fe54a
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.61.0"
+    URL
+    "https://downloads.sourceforge.net/project/boost/boost/1.61.0/boost_1_61_0.tar.bz2"
+    SHA1
+    f84b1a1ce764108ec3c2b7bd7704cf8dfd3c9d01
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.62.0"
+    URL
+    "https://downloads.sourceforge.net/project/boost/boost/1.62.0/boost_1_62_0.tar.bz2"
+    SHA1
+    5fd97433c3f859d8cbab1eaed4156d3068ae3648
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.63.0"
+    URL
+    "https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.bz2"
+    SHA1
+    9f1dd4fa364a3e3156a77dc17aa562ef06404ff6
+)
+
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.64.0"
+    URL
+    "https://downloads.sourceforge.net/project/boost/boost/1.64.0/boost_1_64_0.tar.bz2"
+    SHA1
+    51421ef259a4530edea0fbfc448460fcc5c64edb
+)
+
 # for official boost releases use base url https://boostorg.jfrog.io/artifactory/main/release
 hunter_add_version(
     PACKAGE_NAME
@@ -265,246 +504,6 @@ hunter_add_version(
     "https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.7z"
     SHA1
     90bef80787606e1f4022a877073b2346636fdba3
-)
-
-# up until 1.63 sourcefourge was used, base url https://downloads.sourceforge.net/project/boost/boost
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.64.0"
-    URL
-    "https://downloads.sourceforge.net/project/boost/boost/1.64.0/boost_1_64_0.tar.bz2"
-    SHA1
-    51421ef259a4530edea0fbfc448460fcc5c64edb
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.63.0"
-    URL
-    "https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.bz2"
-    SHA1
-    9f1dd4fa364a3e3156a77dc17aa562ef06404ff6
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.62.0"
-    URL
-    "https://downloads.sourceforge.net/project/boost/boost/1.62.0/boost_1_62_0.tar.bz2"
-    SHA1
-    5fd97433c3f859d8cbab1eaed4156d3068ae3648
-)
-
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.61.0"
-    URL
-    "https://downloads.sourceforge.net/project/boost/boost/1.61.0/boost_1_61_0.tar.bz2"
-    SHA1
-    f84b1a1ce764108ec3c2b7bd7704cf8dfd3c9d01
-)
-
-# Version without tests and docs
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.60.0"
-    URL
-    "https://github.com/hunter-packages/boost/archive/v1.60.0.tar.gz"
-    SHA1
-    28a5b0f739114fde5d4ed1d7f52e5b6cf13fe54a
-)
-
-# Version without tests and docs
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.59.0"
-    URL
-    "https://github.com/hunter-packages/boost/archive/v1.59.0.tar.gz"
-    SHA1
-    28db0e54f9e55ff1230903704836e035f7227fd5
-)
-
-# Version without tests and docs
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.58.0-p1"
-    URL
-    "https://github.com/hunter-packages/boost/archive/v1.58.0-p1.tar.gz"
-    SHA1
-    bc417f98b644f244121c0eb47e810b4c6a6277e8
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.58.0-p0"
-    URL
-    "https://github.com/hunter-packages/boost/archive/v1.58.0-p0.tar.gz"
-    SHA1
-    0c3a2f284e85a61e2d2ccc1a6fdc8dc7a443ef67
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.58.0"
-    URL
-    "http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2/download"
-    SHA1
-    2fc96c1651ac6fe9859b678b165bd78dc211e881
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.57.0"
-    URL
-    "https://github.com/hunter-packages/boost/archive/v1.57.0.tar.gz"
-    SHA1
-    9305649224848860664893342ac29709ebcf42f9
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.56.0"
-    URL
-    "https://github.com/hunter-packages/boost/archive/v1.56.0.tar.gz"
-    SHA1
-    08a45c69e90e5ddc485b770a573dbace8e48932e
-)
-
-# Remove docs and tests
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.55.0-patched-3"
-    URL
-    "https://github.com/hunter-packages/boost/archive/1.55.0-patched-3.tar.gz"
-    SHA1
-    4ae01023ac0dc68570fd1bbcf67cbcd839df04eb
-)
-
-# Apply fix for: https://svn.boost.org/trac/boost/ticket/9332
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.55.0-patched-2"
-    URL
-    "http://sourceforge.net/projects/hunter-packages/files/boost_1_55_0-patched-2.tar.bz2/download"
-    SHA1
-    38c0523dbd27ed6b363ad9255548e942d404b39e
-)
-
-# Workaround for: https://svn.boost.org/trac/boost/ticket/9610
-# http://boost.2283326.n4.nabble.com/config-clang-int128-support-td4653826.html
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.55.0-patched"
-    URL
-    "http://sourceforge.net/projects/hunter-packages/files/boost_1_55_0-patched.tar.bz2/download"
-    SHA1
-    308adf99dbdf0668c9695ff1da075a9e3b71be9d
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.55.0"
-    URL
-    "http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.bz2/download"
-    SHA1
-    cef9a0cc7084b1d639e06cd3bc34e4251524c840
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.54.0"
-    URL
-    "http://sourceforge.net/projects/boost/files/boost/1.54.0/boost_1_54_0.tar.bz2/download"
-    SHA1
-    230782c7219882d0fab5f1effbe86edb85238bf4
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.53.0"
-    URL
-    "http://sourceforge.net/projects/boost/files/boost/1.53.0/boost_1_53_0.tar.bz2/download"
-    SHA1
-    e6dd1b62ceed0a51add3dda6f3fc3ce0f636a7f3
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.52.0"
-    URL
-    "http://sourceforge.net/projects/boost/files/boost/1.52.0/boost_1_52_0.tar.bz2/download"
-    SHA1
-    cddd6b4526a09152ddc5db856463eaa1dc29c5d9
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.51.0"
-    URL
-    "http://sourceforge.net/projects/boost/files/boost/1.51.0/boost_1_51_0.tar.bz2/download"
-    SHA1
-    52ef06895b97cc9981b8abf1997c375ca79f30c5
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.50.0"
-    URL
-    "http://sourceforge.net/projects/boost/files/boost/1.50.0/boost_1_50_0.tar.bz2/download"
-    SHA1
-    ee06f89ed472cf369573f8acf9819fbc7173344e
-)
-
-hunter_add_version(
-    PACKAGE_NAME
-    Boost
-    VERSION
-    "1.49.0"
-    URL
-    "http://sourceforge.net/projects/boost/files/boost/1.49.0/boost_1_49_0.tar.bz2/download"
-    SHA1
-    26a52840e9d12f829e3008589abf0a925ce88524
 )
 
 if(MSVC)


### PR DESCRIPTION
* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**

---

* The first commit reorders the hunter.cmake file into version order and does not contain any functional changes
* There appear to be no new build-required parts of Boost in 1.82 or 1.83.
* Sorry for removing the 7z files, but they require us to set LC_* env vars all over our CI (I can send another version without this part of the change if you would rather).
