### PR TITLE
docs: Add SHA1 calculation onliner and fix sums

### DIFF
--- a/docs/creating-new/create/cmake.rst
+++ b/docs/creating-new/create/cmake.rst
@@ -268,9 +268,8 @@ Download release archive and calculate ``SHA1``:
 
 .. code-block:: none
 
-  > wget https://github.com/hunterbox/hunter_box_1/archive/v1.0.0.tar.gz
-  > openssl sha1 v1.0.0.tar.gz
-  SHA1(v1.0.0.tar.gz)= c724e0f8a4ebc95cf7ba628b89b998b3b3c2697d
+  > wget -O- https://github.com/hunterbox/hunter_box_1/archive/v1.0.0.tar.gz | openssl sha1
+  SHA1(stdin)= 4fa7fe75629f148a61cedc6ba0bce74f177a6747
 
 Add this information to ``cmake/projects/hunter_box_1/hunter.cmake`` file:
 
@@ -292,7 +291,7 @@ Add this information to ``cmake/projects/hunter_box_1/hunter.cmake`` file:
       URL
       "https://github.com/hunterbox/hunter_box_1/archive/v1.0.0.tar.gz"
       SHA1
-      c724e0f8a4ebc95cf7ba628b89b998b3b3c2697d
+      4fa7fe75629f148a61cedc6ba0bce74f177a6747
   )
 
   hunter_pick_scheme(DEFAULT url_sha1_cmake)


### PR DESCRIPTION
This commit improves the documentation of the prcess for adding new packages. It replaces two shell commands for SHA1 calculation with one using a pipe. This allows you not to delete the downloaded archive from the file system later.

The commit also corrects the SHA1 sums shown in the example.

<!--- Use this part of template for other type of changes. Remove the rest. -->
<!--- BEGIN -->

* I've checked this [Git style guide](https://0.readthedocs.io/en/latest/git.html). **[Yes]**
* I've checked this [CMake style guide](https://0.readthedocs.io/en/latest/cmake.html). **[No]**
* My change will work with CMake 3.5 (minimum requirement for Hunter). **[Yes]**
* I will try to keep this pull request as small as possible and will try not to mix unrelated features. **[Yes]**

---
<!--- END -->
