### PR TITLE
ceres-solver: update to 2.2.0-p2 with SuiteSparse v7.5.1-1 support

### DIFF
--- a/cmake/configs/default.cmake
+++ b/cmake/configs/default.cmake
@@ -225,7 +225,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_L
   # - C++17 requirement: https://github.com/ceres-solver/ceres-solver/commit/1274743609bc59621adc9e311cdeeaad7eb65201
   hunter_default_version(ceres-solver VERSION 2.1.0-p1)
 else()
-  hunter_default_version(ceres-solver VERSION 2.2.0-p1)
+  hunter_default_version(ceres-solver VERSION 2.2.0-p2)
 endif()
 hunter_default_version(cgltf VERSION 1.10-f9a8804-p0)
 hunter_default_version(check_ci_tag VERSION 1.0.0)

--- a/cmake/projects/ceres-solver/hunter.cmake
+++ b/cmake/projects/ceres-solver/hunter.cmake
@@ -120,6 +120,17 @@ hunter_add_version(
     e7640e7d3a12bb4b3b36a0a6206ad65108c65326
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    ceres-solver
+    VERSION
+    "2.2.0-p2"
+    URL
+    "https://github.com/cpp-pm/ceres-solver/archive/refs/tags/v2.2.0-p2.tar.gz"
+    SHA1
+    1fe13c3b6188541b4b2d2b8c18119c0caf29e173
+)
+
 hunter_cmake_args(ceres-solver CMAKE_ARGS
     # explicitly remove dependency on gflags (only needed for tests)
     GFLAGS=OFF
@@ -137,6 +148,8 @@ hunter_cmake_args(ceres-solver CMAKE_ARGS
     BUILD_TESTING=OFF
     # also don't build examples: when suitesparse is enabled the examples need Fortran libraries
     BUILD_EXAMPLES=OFF
+    # since SuiteSparse-metis 7.5.1-1 no SuiteSparse::metis target is installed
+    EIGENMETIS=OFF
 )
 
 # Pick a download scheme


### PR DESCRIPTION
Support the latest `SuiteSparse-metis-for-windows` `v7.5.1-1` release, which doesn't provide the `SuiteSparse::metis` target anymore, as Metis is now a private dependency of the SuiteSparse cholmod module.

Also disable `EIGENMETIS` build option as it needs Metis.

* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html)
  step by step carefully. **[Yes]**
