### PR TITLE
Add support for Visual Studio 2022 version 17.10

### DIFF
--- a/cmake/modules/hunter_setup_msvc.cmake
+++ b/cmake/modules/hunter_setup_msvc.cmake
@@ -66,7 +66,7 @@ macro(hunter_setup_msvc)
     string(COMPARE EQUAL "${MSVC_VERSION}" "1900" _vs_14_2015)
     string(REGEX MATCH "^191[0-9]$" _vs_15_2017 "${MSVC_VERSION}")
     string(REGEX MATCH "^192[0-9]$" _vs_16_2019 "${MSVC_VERSION}")
-    string(REGEX MATCH "^193[0-9]$" _vs_17_2022 "${MSVC_VERSION}")
+    string(REGEX MATCH "^19[34][0-9]$" _vs_17_2022 "${MSVC_VERSION}")
 
     if(_vs_8_2005)
       set(HUNTER_MSVC_VERSION "8")


### PR DESCRIPTION
Visual Studio 2022 versions have rolled over from 1930s to 1940s with the release of 17.10
https://learn.microsoft.com/en-us/cpp/overview/compiler-versions