### PR TITLE
docs: fix warning about matrix.json not valid for code highlighting

### DIFF
--- a/docs/creating-new/test/ci.rst
+++ b/docs/creating-new/test/ci.rst
@@ -82,7 +82,6 @@ Build matrix
   This will lead to you project testing toolchains diverge from default ones in the future.
 
 .. literalinclude:: ../../../.github/workflows/ci/matrix.json
-  :language: JSON
 
 Each line defines parameters for a job that will run on `GitHub-hosted runner <https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners>`__:
 


### PR DESCRIPTION
Fixing the following warning:
```sh
Warning, treated as error:
hunter/docs/creating-new/test/ci.rst:84:Could not lex literal_block as "JSON". Highlighting skipped.
```

The referenced codeblock is the following:

```rst
.. literalinclude:: ../../../.github/workflows/ci/matrix.json
  :language: JSON
```

The `matrix.json` file contains `//` comments, which are not valid json tripping the highlighting.

Removing the `:language: JSON` part fixes this warning

Fixes: https://github.com/cpp-pm/hunter/issues/790
