### PR TITLE
docs: msgpack: fix spelling warnings/errors

### DIFF
--- a/docs/packages/pkg/msgpack.rst
+++ b/docs/packages/pkg/msgpack.rst
@@ -1,6 +1,7 @@
 .. spelling::
 
     msgpack
+    msgpackc
 
 .. index:: unsorted ; msgpack
   
@@ -18,7 +19,7 @@ msgpack
 -  Added by `Antal Tátrai <https://github.com/tatraian>`__
    (`pr-406 <https://github.com/ruslo/hunter/pull/406>`__)
 - Available since |hunter|
-- Target library name from "msgpack::msgpack" to "msgpackc-cxx" with `v4.1.3`
+- Target library renamed from ``msgpack::msgpack`` to ``msgpackc-cxx`` with ``v4.1.3``
 
 .. code-block:: cmake
 


### PR DESCRIPTION
The documentation for `msgpack` has two spelling errors:

```
writing output... [ 63%] packages/pkg/msgpack
packages/pkg/msgpack.rst:21:msgpackc:["mudpack"]
packages/pkg/msgpack.rst:21:cxx:["xxx", "xx", "cox", "c xx", "OSX"]

...

 Spelling checker messages written to /home/runner/work/hunter/hunter/docs/_spelling/output.txt
Warning, treated as error:
Found 2 misspelled words
```

Update the documentation properly escaping the target names and in the process making the spellchecker ignoring the "codeblocks".

Fixes: https://github.com/cpp-pm/hunter/issues/794
