### PR TITLE
docs: conf.py: remove deprecated get_html_theme_path call

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,7 +131,6 @@ html_theme = 'default'
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
     html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 ### Suppress warnings: http://stackoverflow.com/a/28778969/2288008 {
 if not on_rtd:


### PR DESCRIPTION
For Sphinx `v8.1.3` compatibility remove the `get_html_theme_path` call.

Fixes: https://github.com/cpp-pm/hunter/issues/807
