### PR TITLE
OpenSSL: drop `libunwind` linking for Clang-based Android NDK

### DIFF
--- a/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
+++ b/cmake/projects/OpenSSL/schemes/url_sha1_openssl.cmake.in
@@ -104,6 +104,14 @@ if(ANDROID)
   # * android-ndk-r17-api-24-arm64-v8a-clang-libcxx14
   # * android-ndk-r18-api-24-arm64-v8a-clang-libcxx14
   list(APPEND configure_opts "-latomic ${CMAKE_EXE_LINKER_FLAGS}")
+
+  # On Clang-based Android NDK toolchains, explicitly linking libunwind is
+  # unnecessary and results in malformed flags like "-l-l:libunwind.a", which
+  # break the build. This block strips such flags from configure options to
+  # ensure successful compilation.
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    string(REPLACE "-l-l:libunwind.a" "" configure_opts "${configure_opts}")
+  endif()
 elseif(RASPBERRY_PI)
   set(configure_opts "linux-generic32")
 elseif(OPENWRT)


### PR DESCRIPTION
Since Android NDK r23+, `unwind` support is bundled in the Clang toolchain and explicit linking to libunwind is no longer required. Linking this library causes build errors on modern NDKs.

This change removes `libunwind` from the configure options to ensure successful builds for NDK r23+.

* I've followed [this guide](https://hunter.readthedocs.io/en/latest/creating-new/update.html) step by step carefully. **Yes**