### PR TITLE
CI: install python requests module to fix upload cache script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,9 @@ jobs:
       if: runner.os == 'Windows'
       run: echo "HUNTER_PYTHON_LOCATION=$env:pythonLocation" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
 
+    - name: Install requests python module for upload script
+      run: python -m pip install requests
+
     - name: Build on Unix
       if: runner.os != 'Windows'
       env:


### PR DESCRIPTION
On the `master` branch the pipelines fail at the `upload-cache-to-github.py` script as it is missing the `requests` python module.

Install it before the build to have a working cache upload again.

Fixes: https://github.com/cpp-pm/hunter/issues/819