### PR TITLE
glog: WITH_UNWIND=OFF ignored with 0.7.1, need to set none

### DIFF
--- a/cmake/projects/glog/hunter.cmake
+++ b/cmake/projects/glog/hunter.cmake
@@ -108,12 +108,24 @@ hunter_add_version(
     470e77edcaad491d2f676987ac5a2e739978dda5
 )
 
+if(HUNTER_glog_VERSION VERSION_GREATER_EQUAL 0.7.1)
+    set(_hunter_glog_with_unwind_off_flag "none")
+else()
+    set(_hunter_glog_with_unwind_off_flag "OFF")
+endif()
+if(HUNTER_glog_VERSION VERSION_LESS 0.7.1)
+    # CMake 4.0+ compatibility with older Glog packages
+    set(_hunter_glog_cmake_compatibility_flag "CMAKE_POLICY_VERSION_MINIMUM=3.5")
+else()
+    set(_hunter_glog_cmake_compatibility_flag "")
+endif()
 # explicitly remove dependency on gflags (only needed for tests)
 hunter_cmake_args(glog CMAKE_ARGS
     WITH_GFLAGS=OFF
-    WITH_UNWIND=OFF # since 0.5.0
+    WITH_UNWIND=${_hunter_glog_with_unwind_off_flag} # since 0.5.0
     WITH_GTEST=OFF # since 0.6.0
     BUILD_TESTING=OFF
+    ${_hunter_glog_cmake_compatibility_flag}
 )
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)


### PR DESCRIPTION
The `WITH_UNWIND=OFF` flag is ignored with `glog` `0.7.1`. One needs to set `none` now to disable the usage of `libunwind`.

Furthermore make older glog versions compatible with CMake 4.0 and newer.
