### PR TITLE
BZip2: CMake 4+ compatibility flag

### DIFF
--- a/cmake/projects/BZip2/hunter.cmake
+++ b/cmake/projects/BZip2/hunter.cmake
@@ -65,10 +65,17 @@ hunter_add_version(
     9125bd674fbe7c8169c8ea6a2a15a414a7dc2f86
 )
 
+if(HUNTER_BZip2_VERSION VERSION_LESS 1.0.9)
+    # CMake 4.0+ compatibility with older BZip2 packages
+    set(_hunter_BZip2_cmake_compatibility_flag "CMAKE_POLICY_VERSION_MINIMUM=3.5")
+else()
+    set(_hunter_BZip2_cmake_compatibility_flag "")
+endif()
 hunter_cmake_args(
     BZip2
     CMAKE_ARGS
     BUILD_TESTING=OFF
+    ${_hunter_BZip2_cmake_compatibility_flag}
 )
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)


### PR DESCRIPTION
Set `CMAKE_POLICY_VERSION_MINIMUM=3.5` to make the project work with CMake 4+.

This fixes the following error:
```
CMake Error at CMakeLists.txt (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```
