### PR TITLE
minizip: CMake 4+ compatibility

### DIFF
--- a/cmake/projects/minizip/hunter.cmake
+++ b/cmake/projects/minizip/hunter.cmake
@@ -53,7 +53,16 @@ hunter_add_version(
     65728dbf7573d3f1826d04a3b686d80eb099d7b8
 )
 
-hunter_cmake_args(minizip CMAKE_ARGS USE_AES=FALSE)
+if(HUNTER_minizip_VERSION VERSION_LESS 1.0.2)
+    # CMake 4.0+ compatibility with older minizip packages
+    set(_hunter_minizip_cmake_compatibility_flag "CMAKE_POLICY_VERSION_MINIMUM=3.5")
+else()
+    set(_hunter_minizip_cmake_compatibility_flag "")
+endif()
+hunter_cmake_args(minizip CMAKE_ARGS
+    USE_AES=FALSE
+    ${_hunter_minizip_cmake_compatibility_flag}
+)
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)
 hunter_cacheable(minizip)


### PR DESCRIPTION
Set `CMAKE_POLICY_VERSION_MINIMUM=3.5` to make the project work with CMake 4+.

This fixes the following error:
```
CMake Error at CMakeLists.txt (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```
