### PR TITLE
termcolor: CMake 4+ compatitibility

### DIFF
--- a/cmake/projects/termcolor/hunter.cmake
+++ b/cmake/projects/termcolor/hunter.cmake
@@ -30,7 +30,16 @@ hunter_add_version(
     c49b9d07c3240ba624e6471a5e461ecaa2fc7dc2
 )
 
-hunter_cmake_args(termcolor CMAKE_ARGS ENABLE_TESTING=OFF)
+if(HUNTER_termcolor_VERSION VERSION_LESS_EQUAL 1.0.1)
+    # CMake 4.0+ compatibility with older termcolor packages
+    set(_hunter_termcolor_cmake_compatibility_flag "CMAKE_POLICY_VERSION_MINIMUM=3.5")
+else()
+    set(_hunter_termcolor_cmake_compatibility_flag "")
+endif()
+hunter_cmake_args(termcolor CMAKE_ARGS
+    ENABLE_TESTING=OFF
+    ${_hunter_termcolor_cmake_compatibility_flag}
+)
 
 hunter_pick_scheme(DEFAULT url_sha1_cmake)
 hunter_cacheable(termcolor)


### PR DESCRIPTION
Set `CMAKE_POLICY_VERSION_MINIMUM=3.5` to make the project work with CMake 4+.

This fixes the following error:
```
CMake Error at CMakeLists.txt (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```
