### PR TITLE
CI: update actions to latest versions

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
     - name: Git checkout with submodules
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6
 
       - name: Manual dispatch, get project name from input
         if: github.event_name == 'workflow_dispatch'
@@ -56,7 +56,7 @@ jobs:
     steps:
 
     - name: Git checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6
 
     - name: Manual dispatch, get project name from input
       if: github.event_name == 'workflow_dispatch'
@@ -103,7 +103,7 @@ jobs:
     steps:
 
     - name: Git checkout with submodules
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -160,7 +160,7 @@ jobs:
     steps:
 
     - name: Git checkout
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v6
 
     - name: Get job status via GitHub API
       uses: octokit/request-action@v2.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           exit 1
         fi
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: toolchains
         path: .github/toolchains


### PR DESCRIPTION
Update the used actions for `checkout` and `upload-artifact` to their latest
versions for `node24` support
- https://github.com/actions/checkout/releases/tag/v6.0.2
- https://github.com/actions/upload-artifact/releases/tag/v7.0.1

Fixes: https://github.com/cpp-pm/hunter/issues/855