### PR TITLE
Protobuf: CMake 4+ support set CMAKE_POLICY_VERSION_MINIMUM=3.5

### DIFF
--- a/cmake/projects/Protobuf/hunter.cmake
+++ b/cmake/projects/Protobuf/hunter.cmake
@@ -182,6 +182,12 @@ hunter_add_version(
     e5b797dbc4e6ad92d0924ae86c130be4354c35b6
 )
 
+if(HUNTER_Protobuf_VERSION VERSION_LESS 3.19.5)
+  # CMake 4.0+ compatibility with older Glog packages
+  set(_hunter_Protobuf_cmake_compatibility_flag "CMAKE_POLICY_VERSION_MINIMUM=3.5")
+else()
+  set(_hunter_Protobuf_cmake_compatibility_flag "")
+endif()
 string(
     COMPARE EQUAL "${CMAKE_SYSTEM_NAME}" "WindowsStore" _hunter_windows_store
 )
@@ -193,6 +199,7 @@ if(ANDROID OR IOS)
         protobuf_BUILD_TESTS=OFF
         protobuf_BUILD_PROTOC=OFF
         protobuf_BUILD_PROTOC_BINARIES=OFF
+        ${_hunter_Protobuf_cmake_compatibility_flag}
   )
 elseif(_hunter_windows_store)
   hunter_cmake_args(
@@ -201,6 +208,7 @@ elseif(_hunter_windows_store)
         protobuf_BUILD_TESTS=OFF
         protobuf_BUILD_PROTOC=OFF
         protobuf_MSVC_STATIC_RUNTIME=OFF # Do not force static runtime
+        ${_hunter_Protobuf_cmake_compatibility_flag}
   )
 elseif(MSVC)
   hunter_cmake_args(
@@ -208,12 +216,14 @@ elseif(MSVC)
       CMAKE_ARGS
         protobuf_BUILD_TESTS=OFF
         protobuf_MSVC_STATIC_RUNTIME=OFF # Do not force static runtime
+        ${_hunter_Protobuf_cmake_compatibility_flag}
   )
 else()
   hunter_cmake_args(
       Protobuf
       CMAKE_ARGS
         protobuf_BUILD_TESTS=OFF
+        ${_hunter_Protobuf_cmake_compatibility_flag}
   )
 endif()
 


### PR DESCRIPTION
Set `CMAKE_POLICY_VERSION_MINIMUM=3.5` to make the project work with CMake 4+.

This fixes the following error:
```
CMake Error at CMakeLists.txt (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```
